### PR TITLE
Mini AOD 74 X

### DIFF
--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -37,6 +37,12 @@
   <use name="SUSYBSMAnalysis/Zprime2muAnalysis"/>
 </library>
 
+<library file="Zprime2muLeptonProducer_miniAOD.cc" name="Zprime2muLeptonProducer_miniAOD">
+  <use name="CommonTools/Utils"/>
+  <use name="DataFormats/PatCandidates"/>
+  <use name="SUSYBSMAnalysis/Zprime2muAnalysis"/>
+</library>
+
 <library file="Zprime2muCombiner.cc" name="Zprime2muCombiner">
   <use name="DataFormats/PatCandidates"/>
   <use name="CommonTools/CandAlgos"/>
@@ -55,12 +61,22 @@
   <use name="TrackingTools/TransientTrack"/>
 </library>
 
+<library file="Zprime2muCompositeCandidatePicker_miniAOD.cc" name="Zprime2muCompositeCandidatePicker_miniAOD">
+  <use name="CommonTools/Utils"/>
+  <use name="DataFormats/PatCandidates"/>
+  <use name="RecoVertex/KalmanVertexFit"/>
+  <use name="RecoVertex/KinematicFit"/>
+  <use name="SUSYBSMAnalysis/Zprime2muAnalysis"/>
+  <use name="TrackingTools/Records"/>
+  <use name="TrackingTools/TransientTrack"/>
+</library>
+
 <library file="GenParticleMerger.cc" name="GenParticleMerger">
   <use name="CommonTools/UtilAlgos"/>
   <use name="DataFormats/HepMCCandidate"/>
 </library>
 
-<library file="AsymmetryFrameAnalysis.cc,AsymmetryParametrizer.cc,CocktailAnalyzer.cc,EfficiencyFromMC.cc,HardInteractionFilter.cc,HardInteractionNtuple.cc,HistosFromPAT.cc,MuonsFromDimuons.cc,PrintEvent.cc,QCDBackground.cc,ResolutionUsingMC.cc,SimpleNtupler.cc,Zprime2muAsymmetry.cc,Zprime2muMassReach.cc" name="Zprime2muAnalyzers">
+<library file="AsymmetryFrameAnalysis.cc,AsymmetryParametrizer.cc,CocktailAnalyzer.cc,EfficiencyFromMC.cc,HardInteractionFilter.cc,HardInteractionNtuple.cc,HistosFromPAT.cc, HistosFromPAT_miniAOD.cc, MuonsFromDimuons.cc,PrintEvent.cc,QCDBackground.cc,ResolutionUsingMC.cc,SimpleNtupler.cc,Zprime2muAsymmetry.cc,Zprime2muMassReach.cc" name="Zprime2muAnalyzers">
   <use name="ostream"/>
   <use name="rootgraphics"/>
   <use name="CommonTools/UtilAlgos"/>

--- a/plugins/HistosFromPAT_miniAOD.cc
+++ b/plugins/HistosFromPAT_miniAOD.cc
@@ -1,0 +1,582 @@
+// JMTBAD make this fill lepton histos from all leptons + those that
+// make it into dileptons always, not just depending on flag.
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TTree.h"
+#include "TMath.h"
+
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/MuonReco/interface/MuonIsolation.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/DileptonUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/GeneralUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/PATUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/ToConcrete.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/TrackUtilities.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"///
+
+class Zprime2muHistosFromPAT_miniAOD : public edm::EDAnalyzer {
+ public:
+  explicit Zprime2muHistosFromPAT_miniAOD(const edm::ParameterSet&);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+ private:
+  void getBSandPV(const edm::Event&);
+  void fillBasicLeptonHistos(const reco::CandidateBaseRef&);
+  void fillOfflineMuonHistos(const pat::Muon*);
+  void fillOfflineElectronHistos(const pat::Electron*);
+  void fillLeptonHistos(const reco::CandidateBaseRef&);
+  void fillLeptonHistos(const edm::View<reco::Candidate>&);
+  void fillLeptonHistosFromDileptons(const pat::CompositeCandidateCollection&);
+  void fillDileptonHistos(const pat::CompositeCandidate&, const edm::Event&);
+  void fillDileptonHistos(const pat::CompositeCandidateCollection&, const edm::Event&);
+
+  edm::InputTag lepton_src;
+  edm::InputTag dilepton_src;
+  const bool leptonsFromDileptons;
+  edm::InputTag beamspot_src;
+  edm::InputTag vertex_src;
+  const bool use_bs_and_pv;
+
+  struct debug_tree_t {
+    unsigned run;
+    unsigned lumi;
+    unsigned event;
+    float mass;
+    short id;
+  };
+
+  debug_tree_t dbg_t;
+  TTree* dbg_tree;
+
+  // mmm bare ptrs
+  const reco::BeamSpot* beamspot;
+  const reco::Vertex*   vertex;
+    bool _usePrescaleWeight;
+    int  _prescaleWeight;
+    
+    double eventWeight;///
+    bool _useMadgraphWeight;///
+    double _madgraphWeight;///
+
+  TH1F* NBeamSpot;
+  TH1F* NVertices;
+  TH1F* NLeptons;
+  TH2F* LeptonSigns;
+  TH1F* LeptonEta;
+  TH1F* LeptonRap;
+  TH1F* LeptonPhi;
+  TH1F* LeptonPt;
+  TH1F* LeptonPz;
+  TH1F* LeptonP;
+  TProfile* LeptonPVsEta;
+  TProfile* LeptonPtVsEta;
+  TH1F* IsoSumPt;
+  TH1F* RelIsoSumPt;
+  TH1F* IsoEcal;   
+  TH1F* IsoHcal;   
+  TH1F* CombIso;
+  TH1F* RelCombIso;
+  TH1F* CombIsoNoECAL;
+  TH1F* RelCombIsoNoECAL;
+  TH1F* IsoNTracks;
+  TH1F* IsoNJets;  
+  TH1F* NPxHits;
+  TH1F* NStHits;
+  TH1F* NTkHits;
+  TH1F* NMuHits;
+  TH1F* NHits;
+  TH1F* NInvalidHits;
+  TH1F* NPxLayers;
+  TH1F* NStLayers;
+  TH1F* NTkLayers;
+  TH1F* Chi2dof;
+  TH1F* TrackD0BS;
+  TH1F* TrackDZBS;
+  TH1F* TrackD0PV;
+  TH1F* TrackDZPV;
+  TH1F* NDileptons;
+  TH1F* DileptonEta;
+  TH1F* DileptonRap;
+  TH1F* DileptonPhi;
+  TH1F* DileptonPt;
+  TH1F* DileptonPz;
+  TH1F* DileptonP;
+  TProfile* DileptonPVsEta;
+  TProfile* DileptonPtVsEta;
+  TH1F* DileptonMass;
+  TH1F* DileptonMassWeight;
+  TH1F* DileptonWithPhotonsMass;
+  TH1F* DileptonDeltaPt;
+  TH1F* DileptonDeltaP;
+  TH2F* DimuonMuonPtErrors;
+  TH1F* DimuonMuonPtErrOverPt;
+  TH1F* DimuonMuonPtErrOverPtM200;
+  TH1F* DimuonMuonPtErrOverPtM500;
+  TH2F* DileptonDaughterIds;
+  TH1F* DileptonDaughterDeltaR;
+  TH1F* DileptonDaughterDeltaPhi;
+  TH1F* DimuonMassVertexConstrained;
+  TH1F* DimuonMassVertexConstrainedWeight;
+  TH1F* DimuonMassVtxConstrainedLog;
+  TH1F* DimuonMassVtxConstrainedLogWeight;
+  TH2F* DimuonMassConstrainedVsUn;
+  TH2F* DimuonMassVertexConstrainedError;
+    //special
+    TH1F* DimuonMassVtx_chi2;
+    TH1F* DimuonMassVtx_prob;
+    //weight
+    TH1F* WeightMadGraph;///
+};
+
+Zprime2muHistosFromPAT_miniAOD::Zprime2muHistosFromPAT_miniAOD(const edm::ParameterSet& cfg)
+  : lepton_src(cfg.getParameter<edm::InputTag>("lepton_src")),
+    dilepton_src(cfg.getParameter<edm::InputTag>("dilepton_src")),
+    leptonsFromDileptons(cfg.getParameter<bool>("leptonsFromDileptons")),
+    beamspot_src(cfg.getParameter<edm::InputTag>("beamspot_src")),
+    vertex_src(cfg.getParameter<edm::InputTag>("vertex_src")),
+    use_bs_and_pv(cfg.getParameter<bool>("use_bs_and_pv")),
+    dbg_tree(0),
+    beamspot(0),
+    vertex(0),
+    _usePrescaleWeight(cfg.getUntrackedParameter<bool>("usePrescaleWeight",false)),
+    _prescaleWeight(1),
+    _useMadgraphWeight(cfg.getParameter<bool>("useMadgraphWeight")),///
+    _madgraphWeight(1.)///
+{
+  std::string title_prefix = cfg.getUntrackedParameter<std::string>("titlePrefix", "");
+  if (title_prefix.size() && title_prefix[title_prefix.size()-1] != ' ')
+    title_prefix += " ";
+  const TString titlePrefix(title_prefix.c_str());
+
+  edm::Service<TFileService> fs;
+
+  TH1::SetDefaultSumw2(true);
+
+  if (cfg.getUntrackedParameter<bool>("debug", false)) {
+    dbg_tree = fs->make<TTree>("t", "");
+    dbg_tree->Branch("tt", &dbg_t, "run/i:lumi:event:mass/F:id/S");
+  }
+ 
+  // Whole-event things.
+  NBeamSpot = fs->make<TH1F>("NBeamSpot", titlePrefix + "# beamspots/event",  2, 0,  2);
+  NVertices = fs->make<TH1F>("NVertices", titlePrefix + "# vertices/event",  40, 0, 40);
+
+  // Basic kinematics.
+
+  // Lepton multiplicity.
+  NLeptons = fs->make<TH1F>("NLeptons", titlePrefix + "# leptons/event", 10, 0, 10);
+
+  // Opposite/like-sign counts.
+  LeptonSigns = fs->make<TH2F>("LeptonSigns", titlePrefix + "lepton sign combinations", 6, 0, 6, 13, -6, 7);
+  LeptonSigns->GetXaxis()->SetTitle("# leptons");
+  LeptonSigns->GetYaxis()->SetTitle("total charge");
+
+  // Lepton eta, y, phi.
+  LeptonEta = fs->make<TH1F>("LeptonEta", titlePrefix + "#eta", 100, -5, 5);
+  LeptonRap = fs->make<TH1F>("LeptonRap", titlePrefix + "y",    100, -5, 5);
+  LeptonPhi = fs->make<TH1F>("LeptonPhi", titlePrefix + "#phi", 100, -TMath::Pi(), TMath::Pi());
+
+  // Lepton momenta: p, p_T, p_z.
+  LeptonPt = fs->make<TH1F>("LeptonPt", titlePrefix + "pT", 5000, 0, 5000);
+  LeptonPz = fs->make<TH1F>("LeptonPz", titlePrefix + "pz", 5000, 0, 5000);
+  LeptonP  = fs->make<TH1F>("LeptonP",  titlePrefix + "p",  5000, 0, 5000);
+
+  // Lepton momenta versus pseudorapidity.
+  LeptonPVsEta  = fs->make<TProfile>("LeptonPVsEta",   titlePrefix + "p vs. #eta",  100, -6, 6);
+  LeptonPtVsEta = fs->make<TProfile>("LeptonPtVsEta",  titlePrefix + "pT vs. #eta", 100, -6, 6);
+
+  // Muon specific histos.
+
+  // Delta R < 0.3 isolation variables.
+  IsoSumPt         = fs->make<TH1F>("IsoSumPt",         titlePrefix + "Iso. (#Delta R < 0.3) #Sigma pT",           50, 0, 50);
+  RelIsoSumPt      = fs->make<TH1F>("RelIsoSumPt",      titlePrefix + "Iso. (#Delta R < 0.3) #Sigma pT / tk. pT",  50, 0, 1);
+  IsoEcal          = fs->make<TH1F>("IsoEcal",          titlePrefix + "Iso. (#Delta R < 0.3) ECAL",                50, 0, 50);
+  IsoHcal          = fs->make<TH1F>("IsoHcal",          titlePrefix + "Iso. (#Delta R < 0.3) HCAL",                50, 0, 50);
+  CombIso          = fs->make<TH1F>("CombIso",          titlePrefix + "Iso. (#Delta R < 0.3), combined",           50, 0, 50);
+  RelCombIso       = fs->make<TH1F>("RelCombIso",       titlePrefix + "Iso. (#Delta R < 0.3), combined / tk. pT",  50, 0, 1);
+  CombIsoNoECAL    = fs->make<TH1F>("CombIsoNoECAL",    titlePrefix + "Iso. (#Delta R < 0.3), combined (no ECAL)", 50, 0, 50);
+  RelCombIsoNoECAL = fs->make<TH1F>("RelCombIsoNoECAL", titlePrefix + "Iso. (#Delta R < 0.3), combined (no ECAL), relative", 50, 0, 50);
+  IsoNTracks       = fs->make<TH1F>("IsoNTracks",       titlePrefix + "Iso. (#Delta R < 0.3) nTracks",             10, 0, 10);
+  IsoNJets         = fs->make<TH1F>("IsoNJets",         titlePrefix + "Iso. (#Delta R < 0.3) nJets",               10, 0, 10);
+
+  // Track hit counts.
+  NPxHits = fs->make<TH1F>("NPxHits", titlePrefix + "# pixel hits",    8, 0,  8);
+  NStHits = fs->make<TH1F>("NStHits", titlePrefix + "# strip hits",   30, 0, 30);
+  NTkHits = fs->make<TH1F>("NTkHits", titlePrefix + "# tracker hits", 40, 0, 40);
+  NMuHits = fs->make<TH1F>("NMuHits", titlePrefix + "# muon hits",    55, 0, 55);
+
+  NHits        = fs->make<TH1F>("NHits",        titlePrefix + "# hits",         78, 0, 78);
+  NInvalidHits = fs->make<TH1F>("NInvalidHits", titlePrefix + "# invalid hits", 78, 0, 78);
+
+  NPxLayers = fs->make<TH1F>("NPxLayers", titlePrefix + "# pixel layers",    8, 0,  8);
+  NStLayers = fs->make<TH1F>("NStLayers", titlePrefix + "# strip layers",   15, 0, 15);
+  NTkLayers = fs->make<TH1F>("NTkLayers", titlePrefix + "# tracker layers", 20, 0, 20);
+
+  // Other track variables.
+  Chi2dof = fs->make<TH1F>("Chi2dof", titlePrefix + "#chi^{2}/dof", 100, 0, 10);
+  TrackD0BS = fs->make<TH1F>("TrackD0BS", titlePrefix + "|d0 wrt BS|", 100, 0, 0.2);
+  TrackDZBS = fs->make<TH1F>("TrackDZBS", titlePrefix + "|dz wrt BS|", 100, 0, 20);
+  TrackD0PV = fs->make<TH1F>("TrackD0PV", titlePrefix + "|d0 wrt PV|", 100, 0, 0.2);
+  TrackDZPV = fs->make<TH1F>("TrackDZPV", titlePrefix + "|dz wrt PV|", 100, 0, 20);
+
+  // Electron specific histos (none yet).
+
+  // Dilepton quantities.
+
+  // Dilepton multiplicity.
+  NDileptons = fs->make<TH1F>("NDileptons", "# dileptons/event" + titlePrefix, 10, 0, 10);
+
+  // Dilepton eta, y, phi.
+  DileptonEta = fs->make<TH1F>("DileptonEta", titlePrefix + "dil. #eta", 100, -5,  5);
+  DileptonRap = fs->make<TH1F>("DileptonRap", titlePrefix + "dil. y",    100, -5,  5);
+  DileptonPhi = fs->make<TH1F>("DileptonPhi", titlePrefix + "dil. #phi", 100, -TMath::Pi(), TMath::Pi());
+
+  // Dilepton momenta: p, p_T, p_z.
+  DileptonPt = fs->make<TH1F>("DileptonPt", titlePrefix + "dil. pT", 5000, 0, 5000);
+  DileptonPz = fs->make<TH1F>("DileptonPz", titlePrefix + "dil. pz", 5000, 0, 5000);
+  DileptonP  = fs->make<TH1F>("DileptonP",  titlePrefix + "dil. p",  5000, 0, 5000);
+  
+  // Dilepton momenta versus pseudorapidity.
+  DileptonPVsEta  = fs->make<TProfile>("DileptonPVsEta",  titlePrefix + "dil. p vs. #eta",  100, -6, 6);
+  DileptonPtVsEta = fs->make<TProfile>("DileptonPtVsEta", titlePrefix + "dil. pT vs. #eta", 100, -6, 6);
+  
+  // Dilepton invariant mass.
+  DileptonMass            = fs->make<TH1F>("DileptonMass",            titlePrefix + "dil. mass", 20000, 0, 20000);
+  DileptonMassWeight      = fs->make<TH1F>("DileptonMassWeight",      titlePrefix + "dil. mass", 20000, 0, 20000);
+  DileptonWithPhotonsMass = fs->make<TH1F>("DileptonWithPhotonsMass", titlePrefix + "res. mass", 20000, 0, 20000);
+  
+  // Plots comparing the daughter lepton momenta.
+  DileptonDeltaPt = fs->make<TH1F>("DileptonDeltaPt",  titlePrefix + "dil. |pT^{1}| - |pT^{2}|", 100, -100, 100);
+  DileptonDeltaP  = fs->make<TH1F>("DileptonDeltaP",   titlePrefix + "dil. |p^{1}| - |p^{2}|",   100, -500, 500);
+
+  // pT errors of daughter muons
+  DimuonMuonPtErrors        = fs->make<TH2F>("DimuonMuonPtErrors",        titlePrefix + "dil. #sigma_{pT}^{1} v. #sigma_{pT}^{2}", 100, 0, 100, 100, 0, 100);
+  DimuonMuonPtErrOverPt     = fs->make<TH1F>("DimuonMuonPtErrOverPt",     titlePrefix + "muon #sigma_{pT}/pT",              200, 0., 1.);
+  DimuonMuonPtErrOverPtM200 = fs->make<TH1F>("DimuonMuonPtErrOverPtM200", titlePrefix + "muon #sigma_{pT}/pT, M > 200 GeV", 200, 0., 1.);
+  DimuonMuonPtErrOverPtM500 = fs->make<TH1F>("DimuonMuonPtErrOverPtM500", titlePrefix + "muon #sigma_{pT}/pT, M > 500 GeV", 200, 0., 1.);
+
+  // More daughter-related info.
+  DileptonDaughterIds = fs->make<TH2F>("DileptonDaughterIds", "", 27, -13, 14, 27, -13, 14);
+  DileptonDaughterDeltaR = fs->make<TH1F>("DileptonDaughterDeltaR", "", 100, 0, 5);
+  DileptonDaughterDeltaPhi = fs->make<TH1F>("DileptonDaughterDeltaPhi", "", 100, 0, 3.15);
+
+  // Dimuons have a vertex-constrained fit: some associated histograms.
+  DimuonMassVertexConstrained = fs->make<TH1F>("DimuonMassVertexConstrained", titlePrefix + "dimu. vertex-constrained mass", 20000, 0, 20000);
+  DimuonMassVertexConstrainedWeight = fs->make<TH1F>("DimuonMassVertexConstrainedWeight", titlePrefix + "dimu. vertex-constrained mass", 20000, 0, 20000);
+  // Mass plot in bins of log(mass)
+  const int    NMBINS = 100;
+  const double MMIN = 60., MMAX = 2100.;
+  double logMbins[NMBINS+1];
+  for (int ibin = 0; ibin <= NMBINS; ibin++)
+    logMbins[ibin] = exp(log(MMIN) + (log(MMAX)-log(MMIN))*ibin/NMBINS);
+  DimuonMassVtxConstrainedLog = fs->make<TH1F>("DimuonMassVtxConstrainedLog", titlePrefix + "dimu vtx-constrained mass in log bins", NMBINS, logMbins);
+  DimuonMassVtxConstrainedLogWeight = fs->make<TH1F>("DimuonMassVtxConstrainedLogWeight", titlePrefix + "dimu vtx-constrained mass in log bins", NMBINS, logMbins);
+  DimuonMassConstrainedVsUn = fs->make<TH2F>("DimuonMassConstrainedVsUn", titlePrefix + "dimu. vertex-constrained vs. non-constrained mass", 200, 0, 3000, 200, 0, 3000);
+  DimuonMassVertexConstrainedError = fs->make<TH2F>("DimuonMassVertexConstrainedError", titlePrefix + "dimu. vertex-constrained mass error vs. mass", 100, 0, 3000, 100, 0, 400);
+    //special
+    DimuonMassVtx_chi2 = fs->make<TH1F>("DimuonMassVtx_chi2", titlePrefix + "dimu. vertex #chi^{2}/dof", 300, 0, 30);
+    DimuonMassVtx_prob = fs->make<TH1F>("DimuonMassVtx_prob", titlePrefix + "dimu. vertex probability", 100, 0, 1);
+    
+     //weight
+     WeightMadGraph = fs->make<TH1F>("weightperevent", titlePrefix + "weight per event", 4, -2,2);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::getBSandPV(const edm::Event& event) {
+  // We store these as bare pointers. Should find better way, but
+  // don't want to pass them around everywhere...
+  edm::Handle<reco::BeamSpot> hbs;
+  event.getByLabel(beamspot_src, hbs);
+  beamspot = hbs.isValid() ? &*hbs : 0; // nice and fragile
+  NBeamSpot->Fill(beamspot != 0);
+
+  edm::Handle<reco::VertexCollection> vertices;
+  event.getByLabel(vertex_src, vertices);
+  vertex = 0;
+  int vertex_count = 0;
+  for (reco::VertexCollection::const_iterator it = vertices->begin(), ite = vertices->end(); it != ite; ++it) {
+    if (it->ndof() > 4 && fabs(it->z()) <= 24 && fabs(it->position().rho()) <= 2) {
+      if (vertex == 0)
+	vertex = &*it;
+      ++vertex_count;
+    }
+  }
+  NVertices->Fill(vertex_count, _madgraphWeight);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillBasicLeptonHistos(const reco::CandidateBaseRef& lep) {
+  LeptonEta->Fill(lep->eta(), _madgraphWeight);
+  LeptonRap->Fill(lep->rapidity(), _madgraphWeight);
+  LeptonPhi->Fill(lep->phi(), _madgraphWeight);
+
+  LeptonPt->Fill(lep->pt(), _madgraphWeight);
+  LeptonPz->Fill(fabs(lep->pz()), _madgraphWeight);
+  LeptonP ->Fill(lep->p(), _madgraphWeight);
+
+  LeptonPtVsEta->Fill(lep->eta(), lep->pt(), _madgraphWeight);
+  LeptonPVsEta ->Fill(lep->eta(), lep->p(), _madgraphWeight);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillOfflineMuonHistos(const pat::Muon* mu) {
+  const reco::MuonIsolation& iso = mu->isolationR03();
+  IsoSumPt   ->Fill(iso.sumPt, _madgraphWeight);
+  RelIsoSumPt->Fill(iso.sumPt / mu->innerTrack()->pt(), _madgraphWeight);
+  IsoEcal    ->Fill(iso.emEt, _madgraphWeight);
+  IsoHcal    ->Fill(iso.hadEt + iso.hoEt, _madgraphWeight);
+  CombIso    ->Fill( iso.sumPt + iso.emEt + iso.hadEt + iso.hoEt, _madgraphWeight);
+  RelCombIso ->Fill((iso.sumPt + iso.emEt + iso.hadEt + iso.hoEt) / mu->innerTrack()->pt(), _madgraphWeight);
+  IsoNTracks ->Fill(iso.nTracks, _madgraphWeight);
+  IsoNJets   ->Fill(iso.nJets, _madgraphWeight);
+
+  CombIsoNoECAL   ->Fill( iso.sumPt + iso.hadEt + iso.hoEt, _madgraphWeight);
+  RelCombIsoNoECAL->Fill((iso.sumPt + iso.hadEt + iso.hoEt) / mu->innerTrack()->pt(), _madgraphWeight);
+
+  reco::TrackRef track = mu->tunePMuonBestTrack();
+  if (!((track.refCore()).isAvailable())) track = mu->muonBestTrack();
+  if (track.isAvailable()) {
+    Chi2dof->Fill(track->normalizedChi2(), _madgraphWeight);
+
+    if (beamspot != 0) {
+      TrackD0BS->Fill(fabs(track->dxy(beamspot->position())), _madgraphWeight);
+      TrackDZBS->Fill(fabs(track->dz (beamspot->position())), _madgraphWeight);
+    }
+
+    if (vertex != 0) {
+      TrackD0PV->Fill(fabs(track->dxy(vertex->position())), _madgraphWeight);
+      TrackDZPV->Fill(fabs(track->dz (vertex->position())), _madgraphWeight);
+    }
+
+    const reco::HitPattern& hp = track->hitPattern();
+    NPxHits->Fill(hp.numberOfValidPixelHits(), _madgraphWeight);
+    NStHits->Fill(hp.numberOfValidStripHits(), _madgraphWeight);
+    NTkHits->Fill(hp.numberOfValidTrackerHits(), _madgraphWeight);
+    NMuHits->Fill(hp.numberOfValidMuonHits(), _madgraphWeight);
+
+    NHits->Fill(hp.numberOfValidHits(), _madgraphWeight);
+    NInvalidHits->Fill(hp.numberOfHits(reco::HitPattern::TRACK_HITS) - hp.numberOfValidHits(), _madgraphWeight);
+    //NInvalidHits->Fill(hp.numberOfHits() - hp.numberOfValidHits());
+    
+    NPxLayers->Fill(hp.pixelLayersWithMeasurement(), _madgraphWeight);
+    NStLayers->Fill(hp.stripLayersWithMeasurement(), _madgraphWeight);
+    NTkLayers->Fill(hp.trackerLayersWithMeasurement(), _madgraphWeight);
+  }
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillOfflineElectronHistos(const pat::Electron* lep) {
+  // Can add electron quantities here.
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillLeptonHistos(const reco::CandidateBaseRef& lep) {
+  fillBasicLeptonHistos(lep);
+  
+  const pat::Muon* muon = toConcretePtr<pat::Muon>(lep);
+  if (muon) fillOfflineMuonHistos(muon);
+  
+  const pat::Electron* electron = toConcretePtr<pat::Electron>(lep);
+  if (electron) fillOfflineElectronHistos(electron);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillLeptonHistos(const edm::View<reco::Candidate>& leptons) {
+  NLeptons->Fill(leptons.size(), _madgraphWeight);
+
+ // JMTBAD this should use leptonsPassingCuts or whatever
+  int total_q = 0;
+  for (size_t i = 0; i < leptons.size(); ++i) {
+    total_q += leptons[i].charge();
+    fillLeptonHistos(leptons.refAt(i));
+  }
+
+  LeptonSigns->Fill(leptons.size(), total_q);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillLeptonHistosFromDileptons(const pat::CompositeCandidateCollection& dileptons) {
+  int nleptons = 0;
+  int total_q = 0;
+
+  pat::CompositeCandidateCollection::const_iterator dil = dileptons.begin(), dile = dileptons.end();
+  for ( ; dil != dile; ++dil)
+    for (size_t i = 0; i < dil->numberOfDaughters(); ++i) {
+      // JMTBAD if photons ever become daughters of the
+      // CompositeCandidate, need to protect against this here
+      fillLeptonHistos(dileptonDaughter(*dil, i));
+      
+      ++nleptons;
+      total_q += dileptonDaughter(*dil, i)->charge();
+    }
+
+  // These become sanity checks.
+  NLeptons->Fill(nleptons, _madgraphWeight);
+  LeptonSigns->Fill(nleptons, total_q, _madgraphWeight);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillDileptonHistos(const pat::CompositeCandidate& dil, const edm::Event& event) {
+  if (dbg_tree) {
+    dbg_t.mass = dil.mass();
+    dbg_t.id = dil.daughter(0)->pdgId() + dil.daughter(1)->pdgId();
+    dbg_tree->Fill();
+  }
+  DileptonEta->Fill(dil.eta(), _madgraphWeight);
+  DileptonRap->Fill(dil.rapidity(), _madgraphWeight);
+  DileptonPhi->Fill(dil.phi(), _madgraphWeight);
+
+  DileptonPt->Fill(dil.pt(), _madgraphWeight);
+  DileptonPz->Fill(fabs(dil.pz()), _madgraphWeight);
+  DileptonP ->Fill(dil.p(), _madgraphWeight);
+
+  DileptonPtVsEta->Fill(dil.eta(), dil.pt(), _madgraphWeight);
+  DileptonPVsEta ->Fill(dil.eta(), dil.p(), _madgraphWeight);
+
+  DileptonMass->Fill(dil.mass(), _madgraphWeight);
+  DileptonMassWeight->Fill(dil.mass(),_prescaleWeight*_madgraphWeight);//?
+  DileptonWithPhotonsMass->Fill(resonanceP4(dil).mass(), _madgraphWeight);
+
+  const reco::CandidateBaseRef& lep0 = dileptonDaughter(dil, 0);
+  const reco::CandidateBaseRef& lep1 = dileptonDaughter(dil, 1);
+
+  if (lep0.isNonnull() && lep1.isNonnull()) {
+    DileptonDeltaPt->Fill(fabs(lep0->pt()) - fabs(lep1->pt()), _madgraphWeight);
+    DileptonDeltaP ->Fill(fabs(lep0->p())  - fabs(lep1->p()), _madgraphWeight);
+
+    const pat::Muon* mu0 = toConcretePtr<pat::Muon>(lep0);
+    const pat::Muon* mu1 = toConcretePtr<pat::Muon>(lep1);
+    if (mu0 && mu1) {
+      reco::TrackRef ref0 = mu0->tunePMuonBestTrack();
+      if (!((ref0.refCore()).isAvailable())) ref0 = mu0->muonBestTrack();
+      reco::TrackRef ref1 = mu1->tunePMuonBestTrack();
+      if (!((ref1.refCore()).isAvailable())) ref1 = mu1->muonBestTrack();
+      
+      const reco::Track* tk0 = &(*ref0);
+      const reco::Track* tk1 = &(*ref1);
+      if (tk0 && tk1) {
+	DimuonMuonPtErrors->Fill(ptError(tk0), ptError(tk1), _madgraphWeight);
+	DimuonMuonPtErrOverPt->Fill(ptError(tk0)/tk0->pt(), _madgraphWeight);
+	DimuonMuonPtErrOverPt->Fill(ptError(tk1)/tk1->pt(), _madgraphWeight);
+	float mass = -999.;
+	// Use mass calculated with the vertex constraint when available
+	if (dil.hasUserFloat("vertexM"))
+	  mass = dil.userFloat("vertexM");
+	else{
+	  edm::LogWarning("fillDileptonHistos") << "+++ Mass calculated without vertex constraint! +++";
+	  mass = dil.mass();
+	}
+	if (mass > 200.) {
+	  DimuonMuonPtErrOverPtM200->Fill(ptError(tk0)/tk0->pt(), _madgraphWeight);
+	  DimuonMuonPtErrOverPtM200->Fill(ptError(tk1)/tk1->pt(), _madgraphWeight);
+	}
+	if (mass > 500.) {
+	  DimuonMuonPtErrOverPtM500->Fill(ptError(tk0)/tk0->pt(), _madgraphWeight);
+	  DimuonMuonPtErrOverPtM500->Fill(ptError(tk1)/tk1->pt(), _madgraphWeight);
+	}
+      }
+    }
+  }
+
+  DileptonDaughterIds->Fill(dil.daughter(0)->pdgId(), dil.daughter(1)->pdgId(), _madgraphWeight);
+
+  DileptonDaughterDeltaR->Fill(reco::deltaR(*dil.daughter(0), *dil.daughter(1)), _madgraphWeight);
+  DileptonDaughterDeltaPhi->Fill(reco::deltaPhi(dil.daughter(0)->phi(), dil.daughter(1)->phi()), _madgraphWeight);
+
+  if (dil.hasUserFloat("vertexM") && dil.hasUserFloat("vertexMError")) {
+    float vertex_mass = dil.userFloat("vertexM");
+    float vertex_mass_err = dil.userFloat("vertexMError");
+      //std::cout<<" filling mass "<<vertex_mass<<std::endl;
+    DimuonMassVertexConstrained->Fill(vertex_mass, _madgraphWeight);
+    DimuonMassVtxConstrainedLog->Fill(vertex_mass, _madgraphWeight);
+    DimuonMassConstrainedVsUn->Fill(dil.mass(), vertex_mass, _madgraphWeight);
+    DimuonMassVertexConstrainedError->Fill(vertex_mass, vertex_mass_err, _madgraphWeight);
+    DimuonMassVertexConstrainedWeight->Fill(vertex_mass,_prescaleWeight*_madgraphWeight);
+    DimuonMassVtxConstrainedLogWeight->Fill(vertex_mass,_prescaleWeight*_madgraphWeight);
+    // special
+    float vertex_chi2 = dil.userFloat("vertex_chi2");
+      DimuonMassVtx_chi2->Fill(vertex_chi2, _madgraphWeight);
+    if (vertex_chi2 > 0 ) {
+        float vertex_ndof = dil.userFloat("vertex_ndof");
+        float vertex_chi2_noNormalized = vertex_chi2*vertex_ndof;
+        DimuonMassVtx_prob->Fill(TMath::Prob(vertex_chi2_noNormalized, vertex_ndof), _madgraphWeight);}
+
+  }
+}
+
+void Zprime2muHistosFromPAT_miniAOD::fillDileptonHistos(const pat::CompositeCandidateCollection& dileptons, const edm::Event& event) {
+  NDileptons->Fill(dileptons.size(), _madgraphWeight);
+
+  pat::CompositeCandidateCollection::const_iterator dil = dileptons.begin(), dile = dileptons.end();
+  for ( ; dil != dile; ++dil)
+    fillDileptonHistos(*dil, event);
+}
+
+void Zprime2muHistosFromPAT_miniAOD::analyze(const edm::Event& event, const edm::EventSetup& setup) {
+  if (dbg_tree) {
+    memset(&dbg_t, 0, sizeof(debug_tree_t));
+    dbg_t.run = event.id().run();
+    dbg_t.lumi = event.luminosityBlock();
+    dbg_t.event = event.id().event();
+  }
+
+
+//  edm::Handle<int> hltPrescale;
+//  edm::Handle<int> l1Prescale;
+
+//  event.getByLabel(edm::InputTag("getPrescales","HLTPrescale","Zprime2muAnalysis"), hltPrescale);
+//  event.getByLabel(edm::InputTag("getPrescales","L1Prescale","Zprime2muAnalysis"), l1Prescale);
+    if (_usePrescaleWeight) {
+        edm::Handle<int> totalPrescale;
+        event.getByLabel(edm::InputTag("getPrescales","TotalPrescale","Zprime2muAnalysis"), totalPrescale);
+        _prescaleWeight = *totalPrescale;
+    }
+//    std::cout<<*hltPrescale<<std::endl;
+//    std::cout<<l1Prescale<<std::endl;
+//    std::cout<<totalPrescale<<std::endl;
+    if (_useMadgraphWeight) {
+        eventWeight = 1.;
+        edm::Handle<GenEventInfoProduct> gen_ev_info;
+        event.getByLabel(edm::InputTag("generator"), gen_ev_info);
+        eventWeight = gen_ev_info->weight();
+        _madgraphWeight = ( eventWeight > 0 ) ? 1 : -1;
+        std::cout<<"eventWeight"<<eventWeight<<"_madgraphWeight"<<_madgraphWeight<<std::endl;
+        WeightMadGraph->Fill(_madgraphWeight);
+    }
+
+  if (use_bs_and_pv)
+    getBSandPV(event);
+
+  edm::Handle<edm::View<reco::Candidate> > leptons;
+  event.getByLabel(lepton_src, leptons);
+
+  if (!leptons.isValid())
+    edm::LogWarning("LeptonHandleInvalid") << "tried to get " << lepton_src << " with edm::Handle<edm::View<reco::Candidate> > and failed!";
+  else {
+    if (!leptonsFromDileptons)
+      fillLeptonHistos(*leptons);
+  }
+
+  edm::Handle<pat::CompositeCandidateCollection> dileptons;
+  event.getByLabel(dilepton_src, dileptons);
+  
+  if (!dileptons.isValid())
+    edm::LogWarning("DileptonHandleInvalid") << "tried to get " << dilepton_src << " and failed!";
+  else {
+    if (leptonsFromDileptons)
+      fillLeptonHistosFromDileptons(*dileptons);
+    
+    fillDileptonHistos(*dileptons, event);
+  }
+}
+
+DEFINE_FWK_MODULE(Zprime2muHistosFromPAT_miniAOD);

--- a/plugins/HistosVertexFromPAT_miniAOD.cc
+++ b/plugins/HistosVertexFromPAT_miniAOD.cc
@@ -1,0 +1,903 @@
+// JMTBAD make this fill lepton histos from all leptons + those that
+// make it into dileptons always, not just depending on flag.
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TProfile.h"
+#include "TTree.h"
+#include "TMath.h"
+
+
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/MuonReco/interface/MuonIsolation.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/HitPattern.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/DileptonUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/GeneralUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/PATUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/ToConcrete.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/TrackUtilities.h"
+
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+
+
+class Zprime2muHistosVertexFromPAT_miniAOD : public edm::EDAnalyzer {
+ public:
+  explicit Zprime2muHistosVertexFromPAT_miniAOD(const edm::ParameterSet&);
+  void analyze(const edm::Event&, const edm::EventSetup&);
+
+ private:
+  void getBSandPV(const edm::Event&);
+  void fillBasicLeptonHistos(const reco::CandidateBaseRef&);
+  void fillOfflineMuonHistos(const pat::Muon*);
+  void fillOfflineElectronHistos(const pat::Electron*);
+  void fillLeptonHistos(const reco::CandidateBaseRef&);
+  void fillLeptonHistos(const edm::View<reco::Candidate>&);
+  void fillLeptonHistosFromDileptons(const pat::CompositeCandidateCollection&);
+  void fillDileptonHistos(const pat::CompositeCandidate&);
+  void fillDileptonHistos(const pat::CompositeCandidateCollection&);
+
+  edm::InputTag lepton_src;
+  edm::InputTag dilepton_src;
+  const bool leptonsFromDileptons;
+  edm::InputTag beamspot_src;
+  edm::InputTag vertex_src;
+  const bool use_bs_and_pv;
+
+  struct debug_tree_t {
+    unsigned run;
+    unsigned lumi;
+    unsigned event;
+    float mass;
+    short id;
+  };
+
+  debug_tree_t dbg_t;
+  TTree* dbg_tree;
+
+  // mmm bare ptrs
+  const reco::BeamSpot* beamspot;
+  const reco::Vertex*   vertex;
+    bool _usePrescaleWeight;
+    int  _prescaleWeight;
+
+  TH1F* NBeamSpot;
+  TH1F* NVertices;
+  TH1F* NLeptons;
+  TH2F* LeptonSigns;
+  TH1F* LeptonEta;
+  TH1F* LeptonRap;
+  TH1F* LeptonPhi;
+  TH1F* LeptonPt;
+  TH1F* LeptonPz;
+  TH1F* LeptonP;
+  TProfile* LeptonPVsEta;
+  TProfile* LeptonPtVsEta;
+  TH1F* IsoSumPt;
+  TH1F* RelIsoSumPt;
+  TH1F* IsoEcal;   
+  TH1F* IsoHcal;   
+  TH1F* CombIso;
+  TH1F* RelCombIso;
+  TH1F* CombIsoNoECAL;
+  TH1F* RelCombIsoNoECAL;
+  TH1F* IsoNTracks;
+  TH1F* IsoNJets;  
+  TH1F* NPxHits;
+  TH1F* NStHits;
+  TH1F* NTkHits;
+  TH1F* NMuHits;
+  TH1F* NHits;
+  TH1F* NInvalidHits;
+  TH1F* NPxLayers;
+  TH1F* NStLayers;
+  TH1F* NTkLayers;
+  TH1F* Chi2dof;
+  TH1F* TrackD0BS;
+  TH1F* TrackDZBS;
+  TH1F* TrackD0PV;
+  TH1F* TrackDZPV;
+  TH1F* NDileptons;
+  TH1F* DileptonEta;
+  TH1F* DileptonRap;
+  TH1F* DileptonPhi;
+  TH1F* DileptonPt;
+  TH1F* DileptonPz;
+  TH1F* DileptonP;
+  TProfile* DileptonPVsEta;
+  TProfile* DileptonPtVsEta;
+  TH1F* DileptonMass;
+  TH1F* DileptonMassWeight;
+  TH1F* DileptonWithPhotonsMass;
+  TH1F* DileptonDeltaPt;
+  TH1F* DileptonDeltaP;
+  TH2F* DimuonMuonPtErrors;
+  TH1F* DimuonMuonPtErrOverPt;
+  TH1F* DimuonMuonPtErrOverPtM200;
+  TH1F* DimuonMuonPtErrOverPtM500;
+  TH2F* DileptonDaughterIds;
+  TH1F* DileptonDaughterDeltaR;
+  TH1F* DileptonDaughterDeltaPhi;
+  TH1F* DimuonMassVertexConstrained;
+  TH1F* DimuonMassVertexConstrainedWeight;
+  TH1F* DimuonMassVtxConstrainedLog;
+  TH1F* DimuonMassVtxConstrainedLogWeight;
+  TH2F* DimuonMassConstrainedVsUn;
+  TH2F* DimuonMassVertexConstrainedError;
+    //special
+    TH1F* DimuonMassVtx_chi2;
+    TH1F* DimuonMassVtx_prob;
+    TH2F* DimuonMassVertexProbMass;
+    TH2F* DimuonMassVertexProbPt;
+    TH2F* DimuonMassVertexProbEta;
+    TH2F* DimuonMassVertexProbDilEta;
+    TH2F* DimuonMassVertexProbAbsEta;
+    TH2F* DimuonMassVertexProbAbsDilEta;
+    TH1F* DimuonMuonPtProb;
+    TH2F* DimuonMuonPtProbVertexProbPt;
+    /////////
+    TH1F* DimuonMassVtx_LeptonEta;
+    TH1F* DimuonMassVtx_LeptonEta_MassRange;
+    
+    TH1F* DimuonMassVtx_prob_BarrelBarrel;
+    TH1F* DimuonMassVtx_prob_EndcapEndcap;
+    TH1F* DimuonMassVtx_prob_EndcapBarrel;
+    
+    TH1F* DimuonMuonPtProb_Barrel;
+    TH1F* DimuonMuonPtError_Barrel;
+    TH1F* DimuonMuonPtErrOverPt_Barrel;
+
+    TH1F* DimuonMuonPtProb_Endcap;
+    TH1F* DimuonMuonPtError_Endcap;
+    TH1F* DimuonMuonPtErrOverPt_Endcap;
+    
+    TH1F* DimuonMassVtx_prob_BarrelBarrel_MassRange;
+    TH1F* DimuonMassVtx_prob_EndcapEndcap_MassRange;
+    TH1F* DimuonMassVtx_prob_EndcapBarrel_MassRange;
+    
+    TH1F* DimuonMuonPtProb_Barrel_MassRange;
+    TH1F* DimuonMuonPtError_Barrel_MassRange;
+    TH1F* DimuonMuonPtErrOverPt_Barrel_MassRange;
+    
+    TH1F* DimuonMuonPtProb_Endcap_MassRange;
+    TH1F* DimuonMuonPtError_Endcap_MassRange;
+    TH1F* DimuonMuonPtErrOverPt_Endcap_MassRange;
+    
+    TH1F* TrackD0BS_Barrel;
+    TH1F* TrackD0PV_Barrel;
+    TH1F* TrackD0BS_Endcap;
+    TH1F* TrackD0PV_Endcap;
+    TH1F* TrackD0BS_Barrel_MassRange;
+    TH1F* TrackD0PV_Barrel_MassRange;
+    TH1F* TrackD0BS_Endcap_MassRange;
+    TH1F* TrackD0PV_Endcap_MassRange;
+    
+    TH1F* TrackIteration;
+    TH1F* TrackIteration_Barrel;
+    TH1F* TrackIteration_Endcap;
+    TH1F* TrackIteration_Barrel_MassRange;
+    TH1F* TrackIteration_Endcap_MassRange;
+    TH2F* TrackIterationVSPtProb;
+    TH2F* TrackIterationVSPtProb_Barrel;
+    TH2F* TrackIterationVSPtProb_Endcap;
+    TH2F* TrackIterationVSPtProb_Barrel_MassRange;
+    TH2F* TrackIterationVSPtProb_Endcap_MassRange;
+    
+    TH2F* TrackIterationVSDimuonMassVtx_prob_BarrelBarrel;
+    TH2F* TrackIterationVSDimuonMassVtx_prob_EndcapEndcap;
+    TH2F* TrackIterationVSDimuonMassVtx_prob_EndcapBarrel;
+    TH2F* TrackIterationVSDimuonMassVtx_prob1314_BarrelBarrel;
+    TH2F* TrackIterationVSDimuonMassVtx_prob1314_EndcapEndcap;
+    TH2F* TrackIterationVSDimuonMassVtx_prob1314_EndcapBarrel;
+    
+    TH2F* TrackIterationVSIsoSumPt;
+    TH2F* TrackIterationVSRelIsoSumPt;
+    TH2F* TrackIterationVSIsoNTracks;
+    TH2F* PtProbVSIsoSumPt;
+    TH2F* PtProbVSRelIsoSumPt;
+    TH2F* PtProbVSIsoNTracks;
+    TH2F* TrackIterationVSLeptonPt;
+    TH2F* TrackIterationVSLeptonTrackerPt;
+    TH2F* PtProbVSLeptonPt;
+    TH2F* PtProbVSLeptonTrackerPt;
+    TH2F* PtTrackerProbVSLeptonTrackerPt;
+
+
+    
+};
+
+Zprime2muHistosVertexFromPAT_miniAOD::Zprime2muHistosVertexFromPAT_miniAOD(const edm::ParameterSet& cfg)
+  : lepton_src(cfg.getParameter<edm::InputTag>("lepton_src")),
+    dilepton_src(cfg.getParameter<edm::InputTag>("dilepton_src")),
+    leptonsFromDileptons(cfg.getParameter<bool>("leptonsFromDileptons")),
+    beamspot_src(cfg.getParameter<edm::InputTag>("beamspot_src")),
+    vertex_src(cfg.getParameter<edm::InputTag>("vertex_src")),
+    use_bs_and_pv(cfg.getParameter<bool>("use_bs_and_pv")),
+    dbg_tree(0),
+    beamspot(0),
+    vertex(0),
+    _usePrescaleWeight(cfg.getUntrackedParameter<bool>("usePrescaleWeight",false)),
+    _prescaleWeight(1)
+{
+  std::string title_prefix = cfg.getUntrackedParameter<std::string>("titlePrefix", "");
+  if (title_prefix.size() && title_prefix[title_prefix.size()-1] != ' ')
+    title_prefix += " ";
+  const TString titlePrefix(title_prefix.c_str());
+
+  edm::Service<TFileService> fs;
+
+  TH1::SetDefaultSumw2(true);
+
+  if (cfg.getUntrackedParameter<bool>("debug", false)) {
+    dbg_tree = fs->make<TTree>("t", "");
+    dbg_tree->Branch("tt", &dbg_t, "run/i:lumi:event:mass/F:id/S");
+  }
+ 
+  // Whole-event things.
+  NBeamSpot = fs->make<TH1F>("NBeamSpot", titlePrefix + "# beamspots/event",  2, 0,  2);
+  NVertices = fs->make<TH1F>("NVertices", titlePrefix + "# vertices/event",  40, 0, 40);
+
+  // Basic kinematics.
+
+  // Lepton multiplicity.
+  NLeptons = fs->make<TH1F>("NLeptons", titlePrefix + "# leptons/event", 10, 0, 10);
+
+  // Opposite/like-sign counts.
+  LeptonSigns = fs->make<TH2F>("LeptonSigns", titlePrefix + "lepton sign combinations", 6, 0, 6, 13, -6, 7);
+  LeptonSigns->GetXaxis()->SetTitle("# leptons");
+  LeptonSigns->GetYaxis()->SetTitle("total charge");
+
+  // Lepton eta, y, phi.
+  LeptonEta = fs->make<TH1F>("LeptonEta", titlePrefix + "#eta", 100, -5, 5);
+  LeptonRap = fs->make<TH1F>("LeptonRap", titlePrefix + "y",    100, -5, 5);
+  LeptonPhi = fs->make<TH1F>("LeptonPhi", titlePrefix + "#phi", 100, -TMath::Pi(), TMath::Pi());
+
+  // Lepton momenta: p, p_T, p_z.
+  LeptonPt = fs->make<TH1F>("LeptonPt", titlePrefix + "pT", 5000, 0, 5000);
+  LeptonPz = fs->make<TH1F>("LeptonPz", titlePrefix + "pz", 5000, 0, 5000);
+  LeptonP  = fs->make<TH1F>("LeptonP",  titlePrefix + "p",  5000, 0, 5000);
+
+  // Lepton momenta versus pseudorapidity.
+  LeptonPVsEta  = fs->make<TProfile>("LeptonPVsEta",   titlePrefix + "p vs. #eta",  100, -6, 6);
+  LeptonPtVsEta = fs->make<TProfile>("LeptonPtVsEta",  titlePrefix + "pT vs. #eta", 100, -6, 6);
+
+  // Muon specific histos.
+
+  // Delta R < 0.3 isolation variables.
+  IsoSumPt         = fs->make<TH1F>("IsoSumPt",         titlePrefix + "Iso. (#Delta R < 0.3) #Sigma pT",           50, 0, 50);
+  RelIsoSumPt      = fs->make<TH1F>("RelIsoSumPt",      titlePrefix + "Iso. (#Delta R < 0.3) #Sigma pT / tk. pT",  50, 0, 1);
+  IsoEcal          = fs->make<TH1F>("IsoEcal",          titlePrefix + "Iso. (#Delta R < 0.3) ECAL",                50, 0, 50);
+  IsoHcal          = fs->make<TH1F>("IsoHcal",          titlePrefix + "Iso. (#Delta R < 0.3) HCAL",                50, 0, 50);
+  CombIso          = fs->make<TH1F>("CombIso",          titlePrefix + "Iso. (#Delta R < 0.3), combined",           50, 0, 50);
+  RelCombIso       = fs->make<TH1F>("RelCombIso",       titlePrefix + "Iso. (#Delta R < 0.3), combined / tk. pT",  50, 0, 1);
+  CombIsoNoECAL    = fs->make<TH1F>("CombIsoNoECAL",    titlePrefix + "Iso. (#Delta R < 0.3), combined (no ECAL)", 50, 0, 50);
+  RelCombIsoNoECAL = fs->make<TH1F>("RelCombIsoNoECAL", titlePrefix + "Iso. (#Delta R < 0.3), combined (no ECAL), relative", 50, 0, 50);
+  IsoNTracks       = fs->make<TH1F>("IsoNTracks",       titlePrefix + "Iso. (#Delta R < 0.3) nTracks",             10, 0, 10);
+  IsoNJets         = fs->make<TH1F>("IsoNJets",         titlePrefix + "Iso. (#Delta R < 0.3) nJets",               10, 0, 10);
+
+  // Track hit counts.
+  NPxHits = fs->make<TH1F>("NPxHits", titlePrefix + "# pixel hits",    8, 0,  8);
+  NStHits = fs->make<TH1F>("NStHits", titlePrefix + "# strip hits",   30, 0, 30);
+  NTkHits = fs->make<TH1F>("NTkHits", titlePrefix + "# tracker hits", 40, 0, 40);
+  NMuHits = fs->make<TH1F>("NMuHits", titlePrefix + "# muon hits",    55, 0, 55);
+
+  NHits        = fs->make<TH1F>("NHits",        titlePrefix + "# hits",         78, 0, 78);
+  NInvalidHits = fs->make<TH1F>("NInvalidHits", titlePrefix + "# invalid hits", 78, 0, 78);
+
+  NPxLayers = fs->make<TH1F>("NPxLayers", titlePrefix + "# pixel layers",    8, 0,  8);
+  NStLayers = fs->make<TH1F>("NStLayers", titlePrefix + "# strip layers",   15, 0, 15);
+  NTkLayers = fs->make<TH1F>("NTkLayers", titlePrefix + "# tracker layers", 20, 0, 20);
+
+  // Other track variables.
+  Chi2dof = fs->make<TH1F>("Chi2dof", titlePrefix + "#chi^{2}/dof", 100, 0, 10);
+  TrackD0BS = fs->make<TH1F>("TrackD0BS", titlePrefix + "|d0 wrt BS|", 100, 0, 0.2);
+  TrackDZBS = fs->make<TH1F>("TrackDZBS", titlePrefix + "|dz wrt BS|", 100, 0, 20);
+  TrackD0PV = fs->make<TH1F>("TrackD0PV", titlePrefix + "|d0 wrt PV|", 100, 0, 0.2);
+  TrackDZPV = fs->make<TH1F>("TrackDZPV", titlePrefix + "|dz wrt PV|", 100, 0, 20);
+
+  // Electron specific histos (none yet).
+
+  // Dilepton quantities.
+
+  // Dilepton multiplicity.
+  NDileptons = fs->make<TH1F>("NDileptons", "# dileptons/event" + titlePrefix, 10, 0, 10);
+
+  // Dilepton eta, y, phi.
+  DileptonEta = fs->make<TH1F>("DileptonEta", titlePrefix + "dil. #eta", 100, -5,  5);
+  DileptonRap = fs->make<TH1F>("DileptonRap", titlePrefix + "dil. y",    100, -5,  5);
+  DileptonPhi = fs->make<TH1F>("DileptonPhi", titlePrefix + "dil. #phi", 100, -TMath::Pi(), TMath::Pi());
+
+  // Dilepton momenta: p, p_T, p_z.
+  DileptonPt = fs->make<TH1F>("DileptonPt", titlePrefix + "dil. pT", 5000, 0, 5000);
+  DileptonPz = fs->make<TH1F>("DileptonPz", titlePrefix + "dil. pz", 5000, 0, 5000);
+  DileptonP  = fs->make<TH1F>("DileptonP",  titlePrefix + "dil. p",  5000, 0, 5000);
+  
+  // Dilepton momenta versus pseudorapidity.
+  DileptonPVsEta  = fs->make<TProfile>("DileptonPVsEta",  titlePrefix + "dil. p vs. #eta",  100, -6, 6);
+  DileptonPtVsEta = fs->make<TProfile>("DileptonPtVsEta", titlePrefix + "dil. pT vs. #eta", 100, -6, 6);
+  
+  // Dilepton invariant mass.
+  DileptonMass            = fs->make<TH1F>("DileptonMass",            titlePrefix + "dil. mass", 2000, 0, 20000);
+  DileptonMassWeight      = fs->make<TH1F>("DileptonMassWeight",      titlePrefix + "dil. mass", 2000, 0, 20000);
+  DileptonWithPhotonsMass = fs->make<TH1F>("DileptonWithPhotonsMass", titlePrefix + "res. mass", 2000, 0, 20000);
+  
+  // Plots comparing the daughter lepton momenta.
+  DileptonDeltaPt = fs->make<TH1F>("DileptonDeltaPt",  titlePrefix + "dil. |pT^{1}| - |pT^{2}|", 100, -100, 100);
+  DileptonDeltaP  = fs->make<TH1F>("DileptonDeltaP",   titlePrefix + "dil. |p^{1}| - |p^{2}|",   100, -500, 500);
+
+  // pT errors of daughter muons
+  DimuonMuonPtErrors        = fs->make<TH2F>("DimuonMuonPtErrors",        titlePrefix + "dil. #sigma_{pT}^{1} v. #sigma_{pT}^{2}", 100, 0, 100, 100, 0, 100);
+  DimuonMuonPtErrOverPt     = fs->make<TH1F>("DimuonMuonPtErrOverPt",     titlePrefix + "muon #sigma_{pT}/pT",              200, 0., 1.);
+  DimuonMuonPtErrOverPtM200 = fs->make<TH1F>("DimuonMuonPtErrOverPtM200", titlePrefix + "muon #sigma_{pT}/pT, M > 200 GeV", 200, 0., 1.);
+  DimuonMuonPtErrOverPtM500 = fs->make<TH1F>("DimuonMuonPtErrOverPtM500", titlePrefix + "muon #sigma_{pT}/pT, M > 500 GeV", 200, 0., 1.);
+
+  // More daughter-related info.
+  DileptonDaughterIds = fs->make<TH2F>("DileptonDaughterIds", "", 27, -13, 14, 27, -13, 14);
+  DileptonDaughterDeltaR = fs->make<TH1F>("DileptonDaughterDeltaR", "", 100, 0, 5);
+  DileptonDaughterDeltaPhi = fs->make<TH1F>("DileptonDaughterDeltaPhi", "", 100, 0, 3.15);
+
+  // Dimuons have a vertex-constrained fit: some associated histograms.
+  DimuonMassVertexConstrained = fs->make<TH1F>("DimuonMassVertexConstrained", titlePrefix + "dimu. vertex-constrained mass", 2000, 0, 20000);
+  DimuonMassVertexConstrainedWeight = fs->make<TH1F>("DimuonMassVertexConstrainedWeight", titlePrefix + "dimu. vertex-constrained mass", 2000, 0, 20000);
+  // Mass plot in bins of log(mass)
+  const int    NMBINS = 100;
+  const double MMIN = 60., MMAX = 2100.;
+  double logMbins[NMBINS+1];
+  for (int ibin = 0; ibin <= NMBINS; ibin++)
+    logMbins[ibin] = exp(log(MMIN) + (log(MMAX)-log(MMIN))*ibin/NMBINS);
+  DimuonMassVtxConstrainedLog = fs->make<TH1F>("DimuonMassVtxConstrainedLog", titlePrefix + "dimu vtx-constrained mass in log bins", NMBINS, logMbins);
+  DimuonMassVtxConstrainedLogWeight = fs->make<TH1F>("DimuonMassVtxConstrainedLogWeight", titlePrefix + "dimu vtx-constrained mass in log bins", NMBINS, logMbins);
+  DimuonMassConstrainedVsUn = fs->make<TH2F>("DimuonMassConstrainedVsUn", titlePrefix + "dimu. vertex-constrained vs. non-constrained mass", 200, 0, 3000, 200, 0, 3000);
+  DimuonMassVertexConstrainedError = fs->make<TH2F>("DimuonMassVertexConstrainedError", titlePrefix + "dimu. vertex-constrained mass error vs. mass", 100, 0, 3000, 100, 0, 400);
+    //special
+    DimuonMassVtx_chi2 = fs->make<TH1F>("DimuonMassVtx_chi2", titlePrefix + "dimu. vertex #chi^{2}/dof", 300, 0, 30);
+    DimuonMassVtx_prob = fs->make<TH1F>("DimuonMassVtx_prob", titlePrefix + "dimu. vertex probability", 1000, 0., 1.);
+    DimuonMassVertexProbMass = fs->make<TH2F>("DimuonMassVertexProbMass", titlePrefix + "dimu. vertex prob vs. mass", 2000, 0, 20000, 1000, 0., 1);
+    DimuonMassVertexProbPt = fs->make<TH2F>("DimuonMassVertexProbPt", titlePrefix + "dimu. vertex prob vs. pt", 500, 0, 5000, 1000, 0., 1);
+    DimuonMassVertexProbEta = fs->make<TH2F>("DimuonMassVertexProbEta", titlePrefix + "dimu. vertex prob vs. muon eta", 100, -6, 6, 1000, 0., 1);
+    DimuonMassVertexProbDilEta = fs->make<TH2F>("DimuonMassVertexProbDilEta", titlePrefix + "dimu. vertex prob vs. dilepton eta", 100, -6, 6, 1000, 0., 1);
+    DimuonMassVertexProbAbsEta = fs->make<TH2F>("DimuonMassVertexProbAbsEta", titlePrefix + "dimu. vertex prob vs. muon |eta|", 100, -6, 6, 1000, 0., 1);
+    DimuonMassVertexProbAbsDilEta = fs->make<TH2F>("DimuonMassVertexProbAbsDilEta", titlePrefix + "dimu. vertex prob vs. dilepton |eta|", 100, -6, 6, 1000, 0., 1);
+    DimuonMuonPtProb = fs->make<TH1F>("DimuonMuonPtProb", titlePrefix + "muon track prob", 1000, 0., 1.);
+    DimuonMuonPtProbVertexProbPt = fs->make<TH2F>("DimuonMuonPtProbVertexProbPt", titlePrefix + "dimu. vertex prob vs. muon track prob", 1000, 0., 1., 1000, 0., 1);
+    
+    /////////
+    DimuonMassVtx_LeptonEta = fs->make<TH1F>("DimuonMassVtx_LeptonEta", titlePrefix + "#eta", 100, -5, 5);
+    DimuonMassVtx_LeptonEta_MassRange = fs->make<TH1F>("DimuonMassVtx_LeptonEta_MassRange", titlePrefix + "#eta 800<M<1200 GeV", 100, -5, 5);
+    
+    DimuonMassVtx_prob_BarrelBarrel= fs->make<TH1F>("DimuonMassVtx_prob_BarrelBarrel", titlePrefix + "dimu. vertex probability both muons |eta|<0.8", 1000, 0., 1.);
+    DimuonMassVtx_prob_EndcapEndcap= fs->make<TH1F>("DimuonMassVtx_prob_EndcapEndcap", titlePrefix + "dimu. vertex probability both muons |eta|>1.", 1000, 0., 1.);
+    DimuonMassVtx_prob_EndcapBarrel= fs->make<TH1F>("DimuonMassVtx_prob_EndcapBarrel", titlePrefix + "dimu. vertex probability one muon |eta|<0.8 && one muon |eta|>1.", 1000, 0., 1.);
+    
+    DimuonMuonPtProb_Barrel= fs->make<TH1F>("DimuonMuonPtProb_Barrel", titlePrefix + "muon track probability |eta|<0.8", 1000, 0., 1.);
+    DimuonMuonPtError_Barrel= fs->make<TH1F>("DimuonMuonPtError_Barrel",        titlePrefix + "dil. #sigma_{pT}^{1} |eta|<0.8", 100, 0, 100);
+    DimuonMuonPtErrOverPt_Barrel= fs->make<TH1F>("DimuonMuonPtErrOverPt_Barrel",     titlePrefix + "muon #sigma_{pT}/pT |eta|<0.8", 200, 0., 1.);
+   
+    DimuonMuonPtProb_Endcap= fs->make<TH1F>("DimuonMuonPtProb_Endcap", titlePrefix + "muon track probability |eta|>1", 1000, 0., 1.);
+    DimuonMuonPtError_Endcap= fs->make<TH1F>("DimuonMuonPtError_Endcap",        titlePrefix + "dil. #sigma_{pT}^{1} |eta|>1", 100, 0, 100);
+    DimuonMuonPtErrOverPt_Endcap= fs->make<TH1F>("DimuonMuonPtErrOverPt_Endcap",     titlePrefix + "muon #sigma_{pT}/pT |eta|>1", 200, 0., 1.);
+    
+    DimuonMassVtx_prob_BarrelBarrel_MassRange= fs->make<TH1F>("DimuonMassVtx_prob_BarrelBarrel_MassRange", titlePrefix + "dimu. vertex probability both muons |eta|<0.8 800<M<1200 GeV", 1000, 0., 1.);
+    DimuonMassVtx_prob_EndcapEndcap_MassRange= fs->make<TH1F>("DimuonMassVtx_prob_EndcapEndcap_MassRange", titlePrefix + "dimu. vertex probability both muons |eta|>1. 800<M<1200 GeV", 1000, 0., 1.);
+    DimuonMassVtx_prob_EndcapBarrel_MassRange= fs->make<TH1F>("DimuonMassVtx_prob_EndcapBarrel_MassRange", titlePrefix + "dimu. vertex probability one muon |eta|<0.8 && one muon |eta|>1. 800<M<1200 GeV", 1000, 0., 1.);
+    
+    DimuonMuonPtProb_Barrel_MassRange= fs->make<TH1F>("DimuonMuonPtProb_Barrel_MassRange", titlePrefix + "muon track probability |eta|<0.8. 800<M<1200 GeV", 1000, 0., 1.);
+    DimuonMuonPtError_Barrel_MassRange= fs->make<TH1F>("DimuonMuonPtError_Barrel_MassRange",        titlePrefix + "dil. #sigma_{pT}^{1} |eta|<0.8 800<M<1200 GeV", 100, 0, 100);
+    DimuonMuonPtErrOverPt_Barrel_MassRange= fs->make<TH1F>("DimuonMuonPtErrOverPt_Barrel_MassRange",     titlePrefix + "muon #sigma_{pT}/pT |eta|<0.8 800<M<1200 GeV", 200, 0., 1.);
+  
+    DimuonMuonPtProb_Endcap_MassRange= fs->make<TH1F>("DimuonMuonPtProb_Endcap_MassRange", titlePrefix + "muon track probability |eta|>1. 800<M<1200 GeV", 1000, 0., 1.);
+    DimuonMuonPtError_Endcap_MassRange= fs->make<TH1F>("DimuonMuonPtError_Endcap_MassRange",        titlePrefix + "dil. #sigma_{pT}^{1} |eta|>1 800<M<1200 GeV", 100, 0, 100);
+    DimuonMuonPtErrOverPt_Endcap_MassRange= fs->make<TH1F>("DimuonMuonPtErrOverPt_Endcap_MassRange",     titlePrefix + "muon #sigma_{pT}/pT |eta|>1 800<M<1200 GeV", 200, 0., 1.);
+    
+    TrackD0BS_Barrel = fs->make<TH1F>("TrackD0BS_Barrel", titlePrefix + "|d0 wrt BS| Barrel", 100, 0, 0.2);
+    TrackD0PV_Barrel = fs->make<TH1F>("TrackD0PV_Barrel", titlePrefix + "|d0 wrt PV| Barrel", 100, 0, 0.2);
+    TrackD0BS_Endcap = fs->make<TH1F>("TrackD0BS_Endcap", titlePrefix + "|d0 wrt BS| Endcap", 100, 0, 0.2);
+    TrackD0PV_Endcap = fs->make<TH1F>("TrackD0PV_Endcap", titlePrefix + "|d0 wrt PV| Endcap", 100, 0, 0.2);
+    TrackD0BS_Barrel_MassRange = fs->make<TH1F>("TrackD0BS_Barrel_MassRange", titlePrefix + "|d0 wrt BS| Barrel 800<M<1200", 100, 0, 0.2);
+    TrackD0PV_Barrel_MassRange = fs->make<TH1F>("TrackD0PV_Barrel_MassRange", titlePrefix + "|d0 wrt PV| Barrel 800<M<1200", 100, 0, 0.2);
+    TrackD0BS_Endcap_MassRange = fs->make<TH1F>("TrackD0BS_Endcap_MassRange", titlePrefix + "|d0 wrt BS| Endcap 800<M<1200", 100, 0, 0.2);
+    TrackD0PV_Endcap_MassRange = fs->make<TH1F>("TrackD0PV_Endcap_MassRange", titlePrefix + "|d0 wrt PV| Endcap 800<M<1200", 100, 0, 0.2);
+    
+    TrackIteration = fs->make<TH1F>("TrackIteration", titlePrefix + "inner track algo()", 16, -0.5, 15.5 );
+    TrackIteration_Barrel = fs->make<TH1F>("TrackIteration_Barrel", titlePrefix + "inner track algo() barrel", 16, -0.5, 15.5 );
+    TrackIteration_Endcap = fs->make<TH1F>("TrackIteration_Endcap", titlePrefix + "inner track algo() endcap", 16, -0.5, 15.5 );
+    TrackIteration_Barrel_MassRange = fs->make<TH1F>("TrackIteration_Barrel_MassRange", titlePrefix + "inner track algo() barrel 800<M<1200", 16, -0.5, 15.5 );
+    TrackIteration_Endcap_MassRange = fs->make<TH1F>("TrackIteration_Endcap_MassRange", titlePrefix + "inner track algo() endcap 800<M<1200", 16, -0.5, 15.5 );
+    TrackIterationVSPtProb = fs->make<TH2F>("TrackIterationVSPtProb", titlePrefix + "inner track algo() vs muon track probability", 16, -0.5, 15.5,  1000, 0., 1.);
+    TrackIterationVSPtProb_Barrel = fs->make<TH2F>("TrackIterationVSPtProb_Barrel", titlePrefix + "inner track algo() vs muon track probability barrel", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSPtProb_Endcap = fs->make<TH2F>("TrackIterationVSPtProb_Endcap", titlePrefix + "inner track algo() vs muon track probability  endcap", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSPtProb_Barrel_MassRange = fs->make<TH2F>("TrackIterationVSPtProb_Barrel_MassRange", titlePrefix + "inner track algo() vs muon track probability  barrel 800<M<1200", 16, -0.5, 15.5,  1000, 0., 1.);
+    TrackIterationVSPtProb_Endcap_MassRange = fs->make<TH2F>("TrackIterationVSPtProb_Endcap_MassRange", titlePrefix + "inner track algo() vs muon track probability endcap 800<M<1200", 16, -0.5, 15.5,  1000, 0., 1.);
+    
+    TrackIterationVSDimuonMassVtx_prob_BarrelBarrel= fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob_BarrelBarrel ", titlePrefix + "inner track algo() vs dimu. vertex probability both muons |eta|<0.8", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSDimuonMassVtx_prob_EndcapEndcap = fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob_EndcapEndcap ", titlePrefix + "inner track algo() vs dimu. vertex probability both muons |eta|>1.", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSDimuonMassVtx_prob_EndcapBarrel = fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob_EndcapBarrel ", titlePrefix + "inner track algo() vs dimu. vertex probability one muon |eta|<0.8 && one muon |eta|>1.", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSDimuonMassVtx_prob1314_BarrelBarrel= fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob1314_BarrelBarrel ", titlePrefix + "inner track algo() =13,14 vs dimu. vertex probability both muons |eta|<0.8", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSDimuonMassVtx_prob1314_EndcapEndcap = fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob1314_EndcapEndcap ", titlePrefix + "inner track algo() =13,14 vs dimu. vertex probability both muons |eta|>1.", 16, -0.5, 15.5, 1000, 0., 1.);
+    TrackIterationVSDimuonMassVtx_prob1314_EndcapBarrel = fs->make<TH2F>("TrackIterationVSDimuonMassVtx_prob1314_EndcapBarrel ", titlePrefix + "inner track algo() =13,14 vs dimu. vertex probability one muon |eta|<0.8 && one muon |eta|>1.", 16, -0.5, 15.5, 1000, 0., 1.);
+    
+    ///////special lepton
+    TrackIterationVSIsoSumPt = fs->make<TH2F>("TrackIterationVSIsoSumPt", titlePrefix + "inner track algo() vs Iso. (#Delta R < 0.3) #Sigma pT", 16, -0.5, 15.5, 50, 0, 50);
+    TrackIterationVSRelIsoSumPt = fs->make<TH2F>("TrackIterationVSRelIsoSumPt", titlePrefix + "inner track algo() vs Iso. (#Delta R < 0.3) #Sigma pT / tk. pT", 16, -0.5, 15.5, 50, 0, 1);
+    TrackIterationVSIsoNTracks = fs->make<TH2F>("TrackIterationVSIsoNTracks", titlePrefix + "inner track algo() vs Iso. (#Delta R < 0.3) nTracks", 16, -0.5, 15.5, 10, 0, 10);
+
+    PtProbVSIsoSumPt = fs->make<TH2F>("PtProbVSIsoSumPt", titlePrefix + "muon track probability vs Iso. (#Delta R < 0.3) #Sigma pT", 1000, 0., 1., 50, 0, 50);
+    PtProbVSRelIsoSumPt = fs->make<TH2F>("PtProbVSRelIsoSumPt", titlePrefix + "muon track probability vs Iso. (#Delta R < 0.3) #Sigma pT / tk. pT", 1000, 0., 1., 50, 0, 1);
+    PtProbVSIsoNTracks = fs->make<TH2F>("PtProbVSIsoNTracks", titlePrefix + "muon track probability vs Iso. (#Delta R < 0.3) nTracks", 1000, 0., 1., 10, 0, 10);
+
+    TrackIterationVSLeptonPt = fs->make<TH2F>("TrackIterationVSLeptonPt", titlePrefix + "inner track algo() vs pT", 16, -0.5, 15.5, 5000, 0, 5000);
+    TrackIterationVSLeptonTrackerPt = fs->make<TH2F>("TrackIterationVSLeptonTrackerPt", titlePrefix + "inner track algo() vs tracker trk pT", 16, -0.5, 15.5, 5000, 0, 5000);
+    PtProbVSLeptonPt = fs->make<TH2F>("PtProbVSLeptonPt", titlePrefix + "muon track probability vs pT", 1000, 0., 1., 5000, 0, 5000);
+    PtProbVSLeptonTrackerPt = fs->make<TH2F>("PtProbVSLeptonTrackerPt", titlePrefix + "muon track probability vs tracker trk pT", 1000, 0., 1., 5000, 0, 5000);
+    PtTrackerProbVSLeptonTrackerPt = fs->make<TH2F>("PtTrackerProbVSLeptonTrackerPt", titlePrefix + "muon tracker track probability vs tracker trk pT", 1000, 0., 1., 5000, 0, 5000);
+
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::getBSandPV(const edm::Event& event) {
+  // We store these as bare pointers. Should find better way, but
+  // don't want to pass them around everywhere...
+  edm::Handle<reco::BeamSpot> hbs;
+  event.getByLabel(beamspot_src, hbs);
+  beamspot = hbs.isValid() ? &*hbs : 0; // nice and fragile
+  NBeamSpot->Fill(beamspot != 0);
+
+  edm::Handle<reco::VertexCollection> vertices;
+  event.getByLabel(vertex_src, vertices);
+  vertex = 0;
+  int vertex_count = 0;
+  for (reco::VertexCollection::const_iterator it = vertices->begin(), ite = vertices->end(); it != ite; ++it) {
+    if (it->ndof() > 4 && fabs(it->z()) <= 24 && fabs(it->position().rho()) <= 2) {
+      if (vertex == 0)
+	vertex = &*it;
+      ++vertex_count;
+    }
+  }
+  NVertices->Fill(vertex_count);
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillBasicLeptonHistos(const reco::CandidateBaseRef& lep) {
+  LeptonEta->Fill(lep->eta());
+  LeptonRap->Fill(lep->rapidity());
+  LeptonPhi->Fill(lep->phi());
+
+  LeptonPt->Fill(lep->pt());
+  LeptonPz->Fill(fabs(lep->pz()));
+  LeptonP ->Fill(lep->p());
+
+  LeptonPtVsEta->Fill(lep->eta(), lep->pt());
+  LeptonPVsEta ->Fill(lep->eta(), lep->p());
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillOfflineMuonHistos(const pat::Muon* mu) {
+  const reco::MuonIsolation& iso = mu->isolationR03();
+  IsoSumPt   ->Fill(iso.sumPt);
+  RelIsoSumPt->Fill(iso.sumPt / mu->innerTrack()->pt());
+  IsoEcal    ->Fill(iso.emEt);
+  IsoHcal    ->Fill(iso.hadEt + iso.hoEt);
+  CombIso    ->Fill( iso.sumPt + iso.emEt + iso.hadEt + iso.hoEt);
+  RelCombIso ->Fill((iso.sumPt + iso.emEt + iso.hadEt + iso.hoEt) / mu->innerTrack()->pt());
+  IsoNTracks ->Fill(iso.nTracks);
+  IsoNJets   ->Fill(iso.nJets);
+
+  CombIsoNoECAL   ->Fill( iso.sumPt + iso.hadEt + iso.hoEt);
+  RelCombIsoNoECAL->Fill((iso.sumPt + iso.hadEt + iso.hoEt) / mu->innerTrack()->pt());
+    
+    ///////////special
+    const reco::TrackRef tk = patmuon::getPickedTrack(*mu);
+    if (tk.isAvailable()) {
+    TrackIterationVSIsoSumPt->Fill(mu->innerTrack()->algo(),iso.sumPt);
+    TrackIterationVSRelIsoSumPt->Fill(mu->innerTrack()->algo(),iso.sumPt / mu->innerTrack()->pt());
+    TrackIterationVSIsoNTracks ->Fill(mu->innerTrack()->algo(),iso.nTracks);
+
+    PtProbVSIsoSumPt->Fill(TMath::Prob(tk->chi2(), tk->ndof()),iso.sumPt);
+    PtProbVSRelIsoSumPt->Fill(TMath::Prob(tk->chi2(), tk->ndof()),iso.sumPt / mu->innerTrack()->pt());
+    PtProbVSIsoNTracks ->Fill(TMath::Prob(tk->chi2(), tk->ndof()),iso.nTracks);
+    
+    TrackIterationVSLeptonPt->Fill(mu->innerTrack()->algo(),tk->pt());
+    TrackIterationVSLeptonTrackerPt->Fill(mu->innerTrack()->algo(),mu->innerTrack()->pt());
+    PtProbVSLeptonPt->Fill(TMath::Prob(tk->chi2(), tk->ndof()),tk->pt());
+    PtProbVSLeptonTrackerPt->Fill(TMath::Prob(tk->chi2(), tk->ndof()),mu->innerTrack()->pt());
+    PtTrackerProbVSLeptonTrackerPt->Fill(TMath::Prob(mu->innerTrack()->chi2(), mu->innerTrack()->ndof()),mu->innerTrack()->pt());
+    }
+    //////////////////
+
+  reco::TrackRef track = mu->tunePMuonBestTrack();
+  if (!((track.refCore()).isAvailable())) track = mu->muonBestTrack();
+  if (track.isAvailable()) {
+    Chi2dof->Fill(track->normalizedChi2());
+
+    if (beamspot != 0) {
+      TrackD0BS->Fill(fabs(track->dxy(beamspot->position())));
+      TrackDZBS->Fill(fabs(track->dz (beamspot->position())));
+    }
+
+    if (vertex != 0) {
+      TrackD0PV->Fill(fabs(track->dxy(vertex->position())));
+      TrackDZPV->Fill(fabs(track->dz (vertex->position())));
+    }
+
+    const reco::HitPattern& hp = track->hitPattern();
+    NPxHits->Fill(hp.numberOfValidPixelHits());
+    NStHits->Fill(hp.numberOfValidStripHits());
+    NTkHits->Fill(hp.numberOfValidTrackerHits());
+    NMuHits->Fill(hp.numberOfValidMuonHits());
+
+    NHits->Fill(hp.numberOfValidHits());
+    NInvalidHits->Fill(hp.numberOfHits(reco::HitPattern::TRACK_HITS) - hp.numberOfValidHits());
+    //NInvalidHits->Fill(hp.numberOfHits() - hp.numberOfValidHits());
+    
+    NPxLayers->Fill(hp.pixelLayersWithMeasurement());
+    NStLayers->Fill(hp.stripLayersWithMeasurement());
+    NTkLayers->Fill(hp.trackerLayersWithMeasurement());
+  }
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillOfflineElectronHistos(const pat::Electron* lep) {
+  // Can add electron quantities here.
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillLeptonHistos(const reco::CandidateBaseRef& lep) {
+  fillBasicLeptonHistos(lep);
+  
+  const pat::Muon* muon = toConcretePtr<pat::Muon>(lep);
+  if (muon) fillOfflineMuonHistos(muon);
+  
+  const pat::Electron* electron = toConcretePtr<pat::Electron>(lep);
+  if (electron) fillOfflineElectronHistos(electron);
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillLeptonHistos(const edm::View<reco::Candidate>& leptons) {
+  NLeptons->Fill(leptons.size());
+
+ // JMTBAD this should use leptonsPassingCuts or whatever
+  int total_q = 0;
+  for (size_t i = 0; i < leptons.size(); ++i) {
+    total_q += leptons[i].charge();
+    fillLeptonHistos(leptons.refAt(i));
+  }
+
+  LeptonSigns->Fill(leptons.size(), total_q);
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillLeptonHistosFromDileptons(const pat::CompositeCandidateCollection& dileptons) {
+  int nleptons = 0;
+  int total_q = 0;
+
+  pat::CompositeCandidateCollection::const_iterator dil = dileptons.begin(), dile = dileptons.end();
+  for ( ; dil != dile; ++dil)
+    for (size_t i = 0; i < dil->numberOfDaughters(); ++i) {
+      // JMTBAD if photons ever become daughters of the
+      // CompositeCandidate, need to protect against this here
+      fillLeptonHistos(dileptonDaughter(*dil, i));
+      
+      ++nleptons;
+      total_q += dileptonDaughter(*dil, i)->charge();
+    }
+
+  // These become sanity checks.
+  NLeptons->Fill(nleptons);
+  LeptonSigns->Fill(nleptons, total_q);
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillDileptonHistos(const pat::CompositeCandidate& dil) {
+  if (dbg_tree) {
+    dbg_t.mass = dil.mass();
+    dbg_t.id = dil.daughter(0)->pdgId() + dil.daughter(1)->pdgId();
+    dbg_tree->Fill();
+  }
+  DileptonEta->Fill(dil.eta());
+  DileptonRap->Fill(dil.rapidity());
+  DileptonPhi->Fill(dil.phi());
+
+  DileptonPt->Fill(dil.pt());
+  DileptonPz->Fill(fabs(dil.pz()));
+  DileptonP ->Fill(dil.p());
+
+  DileptonPtVsEta->Fill(dil.eta(), dil.pt());
+  DileptonPVsEta ->Fill(dil.eta(), dil.p());
+
+  DileptonMass->Fill(dil.mass());
+  DileptonMassWeight->Fill(dil.mass(),_prescaleWeight);
+  DileptonWithPhotonsMass->Fill(resonanceP4(dil).mass());
+
+  const reco::CandidateBaseRef& lep0 = dileptonDaughter(dil, 0);
+  const reco::CandidateBaseRef& lep1 = dileptonDaughter(dil, 1);
+
+  if (lep0.isNonnull() && lep1.isNonnull()) {
+    DileptonDeltaPt->Fill(fabs(lep0->pt()) - fabs(lep1->pt()));
+    DileptonDeltaP ->Fill(fabs(lep0->p())  - fabs(lep1->p()));
+
+    const pat::Muon* mu0 = toConcretePtr<pat::Muon>(lep0);
+    const pat::Muon* mu1 = toConcretePtr<pat::Muon>(lep1);
+    if (mu0 && mu1) {
+      reco::TrackRef ref0 = mu0->tunePMuonBestTrack();
+      if (!((ref0.refCore()).isAvailable())) ref0 = mu0->muonBestTrack();
+      reco::TrackRef ref1 = mu1->tunePMuonBestTrack();
+      if (!((ref1.refCore()).isAvailable())) ref1 = mu1->muonBestTrack();
+      if (tk0 && tk1) {
+	DimuonMuonPtErrors->Fill(ptError(tk0), ptError(tk1));
+	DimuonMuonPtErrOverPt->Fill(ptError(tk0)/tk0->pt());
+	DimuonMuonPtErrOverPt->Fill(ptError(tk1)/tk1->pt());
+	float mass = -999.;
+	// Use mass calculated with the vertex constraint when available
+	if (dil.hasUserFloat("vertexM"))
+	  mass = dil.userFloat("vertexM");
+	else
+	  mass = dil.mass();
+	if (mass > 200.) {
+	  DimuonMuonPtErrOverPtM200->Fill(ptError(tk0)/tk0->pt());
+	  DimuonMuonPtErrOverPtM200->Fill(ptError(tk1)/tk1->pt());
+	}
+	if (mass > 500.) {
+	  DimuonMuonPtErrOverPtM500->Fill(ptError(tk0)/tk0->pt());
+	  DimuonMuonPtErrOverPtM500->Fill(ptError(tk1)/tk1->pt());
+	}
+      }
+    }
+  }
+
+  DileptonDaughterIds->Fill(dil.daughter(0)->pdgId(), dil.daughter(1)->pdgId());
+
+  DileptonDaughterDeltaR->Fill(reco::deltaR(*dil.daughter(0), *dil.daughter(1)));
+  DileptonDaughterDeltaPhi->Fill(reco::deltaPhi(dil.daughter(0)->phi(), dil.daughter(1)->phi())); 
+
+  if (dil.hasUserFloat("vertexM") && dil.hasUserFloat("vertexMError")) {
+    float vertex_mass = dil.userFloat("vertexM");
+    float vertex_mass_err = dil.userFloat("vertexMError");
+      std::cout<<"***************** filling dil mass "<<dil.mass()<<" vtx constrain "<<vertex_mass<<std::endl;
+    DimuonMassVertexConstrained->Fill(vertex_mass);
+    DimuonMassVtxConstrainedLog->Fill(vertex_mass);
+    DimuonMassConstrainedVsUn->Fill(dil.mass(), vertex_mass);
+    DimuonMassVertexConstrainedError->Fill(vertex_mass, vertex_mass_err);
+    DimuonMassVertexConstrainedWeight->Fill(vertex_mass,_prescaleWeight);
+    DimuonMassVtxConstrainedLogWeight->Fill(vertex_mass,_prescaleWeight);
+      
+    // special
+    float vertex_chi2 = dil.userFloat("vertex_chi2");
+      DimuonMassVtx_chi2->Fill(vertex_chi2);
+    if (vertex_chi2 > 0 ) {
+        float vertex_ndof = dil.userFloat("vertex_ndof");
+        float vertex_chi2_noNormalized = vertex_chi2*vertex_ndof;
+        float vertex_prob = TMath::Prob(vertex_chi2_noNormalized, vertex_ndof);
+        DimuonMassVtx_prob->Fill(vertex_prob);
+        DimuonMassVertexProbMass->Fill(dil.mass(), vertex_prob);
+        DimuonMassVertexProbPt->Fill(dil.daughter(0)->pt(), vertex_prob);
+        DimuonMassVertexProbPt->Fill(dil.daughter(1)->pt(), vertex_prob);
+        DimuonMassVertexProbEta->Fill(dil.daughter(0)->eta(), vertex_prob);
+        DimuonMassVertexProbEta->Fill(dil.daughter(1)->eta(), vertex_prob);
+        DimuonMassVertexProbDilEta->Fill(dil.eta(), vertex_prob);
+        DimuonMassVertexProbAbsEta->Fill(fabs(dil.daughter(0)->eta()), vertex_prob);
+        DimuonMassVertexProbAbsEta->Fill(fabs(dil.daughter(1)->eta()), vertex_prob);
+        DimuonMassVertexProbAbsDilEta->Fill(fabs(dil.eta()), vertex_prob);
+        if (lep0.isNonnull() && lep1.isNonnull()) {
+            const pat::Muon* mu0 = toConcretePtr<pat::Muon>(lep0);
+            const pat::Muon* mu1 = toConcretePtr<pat::Muon>(lep1);
+            if (mu0 && mu1) {
+                const reco::TrackRef inner_tk0 = mu0->innerTrack();
+                const reco::TrackRef inner_tk1 = mu1->innerTrack();
+                const reco::Track* tk0 = patmuon::getPickedTrack(*mu0).get();
+                const reco::Track* tk1 = patmuon::getPickedTrack(*mu1).get();
+                const reco::TrackRef track0 = patmuon::getPickedTrack(*mu0);
+                const reco::TrackRef track1 = patmuon::getPickedTrack(*mu1);
+                if (tk0 && tk1) {
+                //if(dil.mass()<=200 && dil.mass()>=100){//solo x dy120
+                    //if(inner_tk0 && inner_tk1){
+                        std::cout<<"ALGO NAME "<<inner_tk0->algo()<<std::endl;
+                        std::cout<<inner_tk0->algoName()<<std::endl;//}
+
+                    DimuonMuonPtProb->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()));
+                    DimuonMuonPtProb->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()));
+                    DimuonMuonPtProbVertexProbPt->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()), vertex_prob);
+                    DimuonMuonPtProbVertexProbPt->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()), vertex_prob);
+                    TrackIteration->Fill(inner_tk0->algo());
+                    TrackIteration->Fill(inner_tk1->algo());
+                    TrackIterationVSPtProb->Fill(inner_tk0->algo(),TMath::Prob(tk0->chi2(), tk0->ndof()));
+                    TrackIterationVSPtProb->Fill(inner_tk1->algo(),TMath::Prob(tk1->chi2(), tk1->ndof()));
+                    
+                    DimuonMassVtx_LeptonEta->Fill(tk0->eta());
+                    DimuonMassVtx_LeptonEta->Fill(tk1->eta());
+                    if(dil.mass()<=1200 && dil.mass()>=800){
+                        DimuonMassVtx_LeptonEta_MassRange->Fill(tk0->eta());
+                        DimuonMassVtx_LeptonEta_MassRange->Fill(tk1->eta());
+                    }
+                    //BARREL
+                    if(fabs(tk0->eta())<0.8){
+                        DimuonMuonPtProb_Barrel->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()));
+                        DimuonMuonPtError_Barrel->Fill(ptError(tk0));
+                        DimuonMuonPtErrOverPt_Barrel->Fill(ptError(tk0)/tk0->pt());
+                        TrackIteration_Barrel->Fill(inner_tk0->algo());
+                        TrackIterationVSPtProb_Barrel->Fill(inner_tk0->algo(),TMath::Prob(tk0->chi2(), tk0->ndof()));
+                        if (beamspot != 0) {TrackD0BS_Barrel->Fill(fabs(track0->dxy(beamspot->position())));}
+                        if (vertex != 0) {TrackD0PV_Barrel->Fill(fabs(track0->dxy(vertex->position())));}
+                    }
+                    if(fabs(tk1->eta())<0.8){
+                        DimuonMuonPtProb_Barrel->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()));
+                        DimuonMuonPtError_Barrel->Fill(ptError(tk1));
+                        DimuonMuonPtErrOverPt_Barrel->Fill(ptError(tk1)/tk1->pt());
+                        TrackIteration_Barrel->Fill(inner_tk1->algo());
+                        TrackIterationVSPtProb_Barrel->Fill(inner_tk1->algo(),TMath::Prob(tk1->chi2(), tk1->ndof()));
+                        if (beamspot != 0) {TrackD0BS_Barrel->Fill(fabs(track1->dxy(beamspot->position())));}
+                        if (vertex != 0) {TrackD0PV_Barrel->Fill(fabs(track1->dxy(vertex->position())));}
+                    }
+                    if(fabs(tk1->eta())<0.8 && fabs(tk0->eta())<0.8){
+                    DimuonMassVtx_prob_BarrelBarrel->Fill(vertex_prob);
+                        if(inner_tk0->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_BarrelBarrel->Fill(inner_tk0->algo(),vertex_prob);
+                        if(inner_tk1->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_BarrelBarrel->Fill(inner_tk1->algo(),vertex_prob);
+                        if((inner_tk0->algo()<=12) && (inner_tk1->algo()<=12)){
+                            TrackIterationVSDimuonMassVtx_prob_BarrelBarrel->Fill(inner_tk0->algo(),vertex_prob);
+                            TrackIterationVSDimuonMassVtx_prob_BarrelBarrel->Fill(inner_tk1->algo(),vertex_prob);
+                        }
+                 
+                    }
+                    if(dil.mass()<1200 && dil.mass()>800){
+                        if(fabs(tk0->eta())<0.8){
+                            DimuonMuonPtProb_Barrel_MassRange->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()));
+                            DimuonMuonPtError_Barrel_MassRange->Fill(ptError(tk0));
+                            DimuonMuonPtErrOverPt_Barrel_MassRange->Fill(ptError(tk0)/tk0->pt());
+                            TrackIteration_Barrel_MassRange->Fill(inner_tk0->algo());
+                            TrackIterationVSPtProb_Barrel_MassRange->Fill(inner_tk0->algo(),TMath::Prob(tk0->chi2(), tk0->ndof()));
+                            if (beamspot != 0) {TrackD0BS_Barrel_MassRange->Fill(fabs(track0->dxy(beamspot->position())));}
+                            if (vertex != 0) {TrackD0PV_Barrel_MassRange->Fill(fabs(track0->dxy(vertex->position())));}
+                        }
+                        if(fabs(tk1->eta())<0.8){
+                            DimuonMuonPtProb_Barrel_MassRange->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()));
+                            DimuonMuonPtError_Barrel_MassRange->Fill(ptError(tk1));
+                            DimuonMuonPtErrOverPt_Barrel_MassRange->Fill(ptError(tk1)/tk1->pt());
+                            TrackIteration_Barrel_MassRange->Fill(inner_tk1->algo());
+                            TrackIterationVSPtProb_Barrel_MassRange->Fill(inner_tk1->algo(),TMath::Prob(tk1->chi2(), tk1->ndof()));
+                            if (beamspot != 0) {TrackD0BS_Barrel_MassRange->Fill(fabs(track1->dxy(beamspot->position())));}
+                            if (vertex != 0) {TrackD0PV_Barrel_MassRange->Fill(fabs(track1->dxy(vertex->position())));}
+                        }
+                        if(fabs(tk1->eta())<0.8 && fabs(tk0->eta())<0.8){
+                            DimuonMassVtx_prob_BarrelBarrel_MassRange->Fill(vertex_prob);
+                        }
+                    }
+                    //ENDCAP
+                    if(fabs(tk0->eta())>1.){
+                        DimuonMuonPtProb_Endcap->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()));
+                        DimuonMuonPtError_Endcap->Fill(ptError(tk0));
+                        DimuonMuonPtErrOverPt_Endcap->Fill(ptError(tk0)/tk0->pt());
+                        TrackIteration_Endcap->Fill(inner_tk0->algo());
+                        TrackIterationVSPtProb_Endcap->Fill(inner_tk0->algo(),TMath::Prob(tk0->chi2(), tk0->ndof()));
+                        if (beamspot != 0) {TrackD0BS_Endcap->Fill(fabs(track0->dxy(beamspot->position())));}
+                        if (vertex != 0) {TrackD0PV_Endcap->Fill(fabs(track0->dxy(vertex->position())));}
+                    }
+                    if(fabs(tk1->eta())>1.){
+                        DimuonMuonPtProb_Endcap->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()));
+                        DimuonMuonPtError_Endcap->Fill(ptError(tk1));
+                        DimuonMuonPtErrOverPt_Endcap->Fill(ptError(tk1)/tk1->pt());
+                        TrackIteration_Endcap->Fill(inner_tk1->algo());
+                        TrackIterationVSPtProb_Endcap->Fill(inner_tk1->algo(),TMath::Prob(tk1->chi2(), tk1->ndof()));
+                        if (beamspot != 0) {TrackD0BS_Endcap->Fill(fabs(track1->dxy(beamspot->position())));}
+                        if (vertex != 0) {TrackD0PV_Endcap->Fill(fabs(track1->dxy(vertex->position())));}
+                    }
+                    if(fabs(tk1->eta())>1. && fabs(tk0->eta())>1.){
+                        DimuonMassVtx_prob_EndcapEndcap->Fill(vertex_prob);
+                        if(inner_tk0->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_EndcapEndcap->Fill(inner_tk0->algo(),vertex_prob);
+                        if(inner_tk1->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_EndcapEndcap->Fill(inner_tk1->algo(),vertex_prob);
+                        if((inner_tk0->algo()<=12) && (inner_tk1->algo()<=12)){
+                            TrackIterationVSDimuonMassVtx_prob_EndcapEndcap->Fill(inner_tk0->algo(),vertex_prob);
+                            TrackIterationVSDimuonMassVtx_prob_EndcapEndcap->Fill(inner_tk1->algo(),vertex_prob);
+                        }
+                    }
+                    //ENDCAPBARREL
+                    if((fabs(tk1->eta())>1. && fabs(tk0->eta())<0.8) || (fabs(tk0->eta())>1. && fabs(tk1->eta())<0.8)){
+                        DimuonMassVtx_prob_EndcapBarrel->Fill(vertex_prob);
+                        if(inner_tk0->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_EndcapBarrel->Fill(inner_tk0->algo(),vertex_prob);
+                        if(inner_tk1->algo()>12)TrackIterationVSDimuonMassVtx_prob1314_EndcapBarrel->Fill(inner_tk1->algo(),vertex_prob);
+                        if((inner_tk0->algo()<=12) && (inner_tk1->algo()<=12)){
+                            TrackIterationVSDimuonMassVtx_prob_EndcapBarrel->Fill(inner_tk0->algo(),vertex_prob);
+                            TrackIterationVSDimuonMassVtx_prob_EndcapBarrel->Fill(inner_tk1->algo(),vertex_prob);
+                        }
+                    }
+                    if(dil.mass()<=1200 && dil.mass()>=800){
+                        if(fabs(tk0->eta())>1.){
+                            DimuonMuonPtProb_Endcap_MassRange->Fill(TMath::Prob(tk0->chi2(), tk0->ndof()));
+                            DimuonMuonPtError_Endcap_MassRange->Fill(ptError(tk0));
+                            DimuonMuonPtErrOverPt_Endcap_MassRange->Fill(ptError(tk0)/tk0->pt());
+                            TrackIteration_Endcap_MassRange->Fill(inner_tk0->algo());
+                            TrackIterationVSPtProb_Endcap_MassRange->Fill(inner_tk0->algo(),TMath::Prob(tk0->chi2(), tk0->ndof()));
+                            if (beamspot != 0) {TrackD0BS_Endcap_MassRange->Fill(fabs(track0->dxy(beamspot->position())));}
+                            if (vertex != 0) {TrackD0PV_Endcap_MassRange->Fill(fabs(track0->dxy(vertex->position())));}
+                        }
+                        if(fabs(tk1->eta())>1.){
+                            DimuonMuonPtProb_Endcap_MassRange->Fill(TMath::Prob(tk1->chi2(), tk1->ndof()));
+                            DimuonMuonPtError_Endcap_MassRange->Fill(ptError(tk1));
+                            DimuonMuonPtErrOverPt_Endcap_MassRange->Fill(ptError(tk1)/tk1->pt());
+                            TrackIteration_Endcap_MassRange->Fill(inner_tk1->algo());
+                            TrackIterationVSPtProb_Endcap_MassRange->Fill(inner_tk1->algo(),TMath::Prob(tk1->chi2(), tk1->ndof()));
+                            if (beamspot != 0) {TrackD0BS_Endcap_MassRange->Fill(fabs(track1->dxy(beamspot->position())));}
+                            if (vertex != 0) {TrackD0PV_Endcap_MassRange->Fill(fabs(track1->dxy(vertex->position())));}
+                        }
+                        if(fabs(tk1->eta())>1. && fabs(tk0->eta())>1.){
+                            DimuonMassVtx_prob_EndcapEndcap_MassRange->Fill(vertex_prob);
+                        }
+                        //ENDCAPBARREL
+                        if((fabs(tk1->eta())>1. && fabs(tk0->eta())<0.8) || (fabs(tk0->eta())>1. && fabs(tk1->eta())<0.8)){
+                            DimuonMassVtx_prob_EndcapBarrel_MassRange->Fill(vertex_prob);
+                        }
+                    }
+                    
+                    
+                }//}//solo per dy120
+            }
+        
+        }
+        
+        
+    }
+
+  }
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::fillDileptonHistos(const pat::CompositeCandidateCollection& dileptons) {
+  NDileptons->Fill(dileptons.size());
+
+  pat::CompositeCandidateCollection::const_iterator dil = dileptons.begin(), dile = dileptons.end();
+  for ( ; dil != dile; ++dil)
+    fillDileptonHistos(*dil);
+}
+
+void Zprime2muHistosVertexFromPAT_miniAOD::analyze(const edm::Event& event, const edm::EventSetup& setup) {
+  if (dbg_tree) {
+    memset(&dbg_t, 0, sizeof(debug_tree_t));
+    dbg_t.run = event.id().run();
+    dbg_t.lumi = event.luminosityBlock();
+    dbg_t.event = event.id().event();
+  }
+
+
+//  edm::Handle<int> hltPrescale;
+//  edm::Handle<int> l1Prescale;
+
+//  event.getByLabel(edm::InputTag("getPrescales","HLTPrescale","Zprime2muAnalysis"), hltPrescale);
+//  event.getByLabel(edm::InputTag("getPrescales","L1Prescale","Zprime2muAnalysis"), l1Prescale);
+    if (_usePrescaleWeight) {
+        edm::Handle<int> totalPrescale;
+        event.getByLabel(edm::InputTag("getPrescales","TotalPrescale","Zprime2muAnalysis"), totalPrescale);
+        _prescaleWeight = *totalPrescale;
+    }
+//    std::cout<<*hltPrescale<<std::endl;
+//    std::cout<<l1Prescale<<std::endl;
+//    std::cout<<totalPrescale<<std::endl;
+
+
+  if (use_bs_and_pv)
+    getBSandPV(event);
+
+  edm::Handle<edm::View<reco::Candidate> > leptons;
+  event.getByLabel(lepton_src, leptons);
+
+  if (!leptons.isValid())
+    edm::LogWarning("LeptonHandleInvalid") << "tried to get " << lepton_src << " with edm::Handle<edm::View<reco::Candidate> > and failed!";
+  else {
+    if (!leptonsFromDileptons)
+      fillLeptonHistos(*leptons);
+  }
+
+  edm::Handle<pat::CompositeCandidateCollection> dileptons;
+  event.getByLabel(dilepton_src, dileptons);
+  
+  if (!dileptons.isValid())
+    edm::LogWarning("DileptonHandleInvalid") << "tried to get " << dilepton_src << " and failed!";
+  else {
+    if (leptonsFromDileptons)
+      fillLeptonHistosFromDileptons(*dileptons);
+    
+    fillDileptonHistos(*dileptons);
+  }
+}
+
+DEFINE_FWK_MODULE(Zprime2muHistosVertexFromPAT_miniAOD);

--- a/plugins/Zprime2muCompositeCandidatePicker_miniAOD.cc
+++ b/plugins/Zprime2muCompositeCandidatePicker_miniAOD.cc
@@ -1,0 +1,339 @@
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/VertexTools/interface/InvariantMassFromVertex.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/DileptonUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/PATUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/TrackUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/ToConcrete.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+
+class Zprime2muCompositeCandidatePicker_miniAOD : public edm::EDProducer {
+public:
+  explicit Zprime2muCompositeCandidatePicker_miniAOD(const edm::ParameterSet&);
+  
+private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  // Helper stuff.
+  struct reverse_mass_sort {
+    bool operator()(const pat::CompositeCandidate& lhs, const pat::CompositeCandidate& rhs) {
+      return lhs.mass() > rhs.mass();
+    }
+  };
+
+  struct lepton_pt_sort {
+    bool operator()(const pat::CompositeCandidate& lhs, const pat::CompositeCandidate& rhs) {
+      // Sort by pT: a pair with two highest-pT muons wins.
+      const reco::CandidateBaseRef& lhs_mu0 = dileptonDaughter(lhs, 0);
+      const reco::CandidateBaseRef& lhs_mu1 = dileptonDaughter(lhs, 1);
+      const reco::CandidateBaseRef& rhs_mu0 = dileptonDaughter(rhs, 0);
+      const reco::CandidateBaseRef& rhs_mu1 = dileptonDaughter(rhs, 1);
+      // Get the unique ids of the dilepton daughters, as well as their pT's.
+      int lhs_id0 = lhs_mu0.key();
+      int lhs_id1 = lhs_mu1.key();
+      int rhs_id0 = rhs_mu0.key();
+      int rhs_id1 = rhs_mu1.key();
+      double lhs_pt0 = lhs_mu0->pt();
+      double lhs_pt1 = lhs_mu1->pt();
+      double rhs_pt0 = rhs_mu0->pt();
+      double rhs_pt1 = rhs_mu1->pt();
+      //std::ostringstream out;
+      //out << " lhs0: " << lhs_id0 << " " << lhs_pt0 << "\n";
+      //out << " lhs1: " << lhs_id1 << " " << lhs_pt1 << "\n";
+      //out << " rhs0: " << rhs_id0 << " " << rhs_pt0 << "\n";
+      //out << " rhs1: " << rhs_id1 << " " << rhs_pt1 << "\n";
+      //edm::LogDebug("Sort dileptons") << out.str();
+      // Sort muons in each dimuon in decreasing order of pT
+      if (lhs_pt0 < lhs_pt1) {
+	double tmp_pt = lhs_pt0;
+	lhs_pt0 = lhs_pt1;
+	lhs_pt1 = tmp_pt;
+	int tmp_id = lhs_id0;
+	lhs_id0 = lhs_id1;
+	lhs_id1 = tmp_id;
+      }
+      if (rhs_pt0 < rhs_pt1) {
+	double tmp_pt = rhs_pt0;
+	rhs_pt0 = rhs_pt1;
+	rhs_pt1 = tmp_pt;
+	int tmp_id = rhs_id0;
+	rhs_id0 = rhs_id1;
+	rhs_id1 = tmp_id;
+      }
+      // In sorting by pT, if there are more than four muons, only the
+      // highest-ranking and lowest-ranking dimuons are well defined.
+      // That's OK because we really care only about the
+      // highest-ranking dimuon.
+      if (lhs_id0 == rhs_id0 && lhs_id1 == rhs_id1) {
+	edm::LogWarning("Sort dileptons") << "+++ Two identical dimuons found? +++";
+	return false;
+      }
+      else if (lhs_id0 == rhs_id0 && lhs_pt1 > rhs_pt1)
+	return true;
+      else if (lhs_id1 == rhs_id1 && lhs_pt0 > rhs_pt0)
+	return true;
+      else if (lhs_id0 != rhs_id0 && lhs_id1 != rhs_id1 && lhs_pt0 > rhs_pt0 && lhs_pt1 > rhs_pt1)
+	return true;
+      else
+	return false;
+    }
+  };
+  
+  void remove_overlap(pat::CompositeCandidateCollection&) const;
+  std::vector<reco::TransientTrack> get_transient_tracks(const pat::CompositeCandidate&) const;
+
+  // Evaluate cuts. Return values are pair<cut decision, variable or
+  // variables to embed>. The cut decision should be made whether
+  // we're actually going to drop the candidate because of this
+  // decision or not (controlled by the cut_on_* variables); that will
+  // be handled in the loop in produce.
+  std::pair<bool, float>             back_to_back_cos_angle(const pat::CompositeCandidate&) const;
+  std::pair<bool, CachingVertex<5> > vertex_constrained_fit(const pat::CompositeCandidate&) const;
+  std::pair<bool, float>             dpt_over_pt(const pat::CompositeCandidate&) const;
+
+  // If the variable to embed in the methods above is a simple int or
+  // float or is going to be embedded wholesale with the generic
+  // userData mechanism, we'll do those explicitly in the loop in
+  // produce. Otherwise if it's more complicated, the methods here
+  // take care of it.
+  void embed_vertex_constrained_fit(pat::CompositeCandidate&, const CachingVertex<5>& vtx) const;
+
+  const edm::InputTag src;
+  StringCutObjectSelector<pat::CompositeCandidate> selector;
+
+  const unsigned max_candidates;
+  const bool sort_by_pt;
+  const bool do_remove_overlap;
+
+  const bool cut_on_back_to_back_cos_angle;
+  const double back_to_back_cos_angle_min;
+
+  const bool cut_on_vertex_chi2;
+  const double vertex_chi2_max;
+
+  const bool cut_on_dpt_over_pt;
+  const double dpt_over_pt_max;
+
+  edm::ESHandle<TransientTrackBuilder> ttkb;
+};
+
+Zprime2muCompositeCandidatePicker_miniAOD::Zprime2muCompositeCandidatePicker_miniAOD(const edm::ParameterSet& cfg)
+  : src(cfg.getParameter<edm::InputTag>("src")),
+    selector(cfg.getParameter<std::string>("cut")),
+    max_candidates(cfg.getParameter<unsigned>("max_candidates")),
+    sort_by_pt(cfg.getParameter<bool>("sort_by_pt")),
+    do_remove_overlap(cfg.getParameter<bool>("do_remove_overlap")),
+    cut_on_back_to_back_cos_angle(cfg.existsAs<double>("back_to_back_cos_angle_min")),
+    back_to_back_cos_angle_min(cut_on_back_to_back_cos_angle ? cfg.getParameter<double>("back_to_back_cos_angle_min") : -2),
+    cut_on_vertex_chi2(cfg.existsAs<double>("vertex_chi2_max")),
+    vertex_chi2_max(cut_on_vertex_chi2 ? cfg.getParameter<double>("vertex_chi2_max") : 1e99),
+    cut_on_dpt_over_pt(cfg.existsAs<double>("dpt_over_pt_max")),
+    dpt_over_pt_max(cut_on_dpt_over_pt ? cfg.getParameter<double>("dpt_over_pt_max") : 1e99)
+{
+  produces<pat::CompositeCandidateCollection>();
+}
+
+void Zprime2muCompositeCandidatePicker_miniAOD::remove_overlap(pat::CompositeCandidateCollection& cands) const {
+  // For the list of CompositeCandidates, find any that share leptons
+  // and remove one of them. The sort order of the input is used to
+  // determine which of the pair is to be removed: we keep the first
+  // one.
+
+  // Don't bother doing anything if there's just one candidate.
+  if (cands.size() < 2) return; 
+
+  pat::CompositeCandidateCollection::iterator p, q;
+  for (p = cands.begin(); p != cands.end() - 1; ) {
+    for (q = p + 1; q != cands.end(); ++q) {         
+      // Check to see if any of the leptons in p is in q also. If so,
+      // remove q (e.g. the one with lower invariant mass since we
+      // have sorted the vector already), reset pointers and restart.
+
+      // To do this we need the unique ids of the daughters, i.e. the
+      // refs into the original lepton collections.
+      typedef std::vector<reco::CandidateBaseRef> refs;
+      refs prefs, qrefs;
+      for (size_t i = 0; i < p->numberOfDaughters(); ++i)
+	prefs.push_back(p->daughter(i)->masterClone());
+      for (size_t i = 0; i < q->numberOfDaughters(); ++i)
+	qrefs.push_back(q->daughter(i)->masterClone());
+
+      // Compare every pair of (pref, qref) to check for any lepton
+      // being shared.
+      bool any_shared = false;
+      refs::const_iterator pr = prefs.begin(), pre = prefs.end(),
+	qr = qrefs.begin(), qre = qrefs.end();
+      for ( ; pr != pre && !any_shared; ++pr)
+	for ( ; qr != qre && !any_shared; ++qr)
+	  if (pr == qr)
+	    any_shared = true;
+
+      if (any_shared) {
+	cands.erase(q);
+	p = cands.begin();
+      }
+      else
+	++p;
+    }
+  }
+}
+
+std::vector<reco::TransientTrack> Zprime2muCompositeCandidatePicker_miniAOD::get_transient_tracks(const pat::CompositeCandidate& dil) const {
+  // Get TransientTracks (for use in e.g. the vertex fit) for each of
+  // the muon tracks, using e.g. the cocktail momentum.
+
+  std::vector<reco::TransientTrack> ttv;
+  const size_t n = dil.numberOfDaughters();
+  for (size_t i = 0; i < n; ++i) {
+    const pat::Muon* mu = toConcretePtr<pat::Muon>(dileptonDaughter(dil, i));
+    assert(mu);
+    const reco::TrackRef& tk = mu->tunePMuonBestTrack();
+    //if (!((tk.refCore()).isAvailable())) tk = mu->muonBestTrack();
+    ttv.push_back(ttkb->build(tk));
+  }
+
+  return ttv;
+}
+
+std::pair<bool, float> Zprime2muCompositeCandidatePicker_miniAOD::back_to_back_cos_angle(const pat::CompositeCandidate& dil) const {
+  // Back-to-back cut to kill cosmics.
+  assert(dil.numberOfDaughters() == 2);
+  const float cos_angle = dil.daughter(0)->momentum().Dot(dil.daughter(1)->momentum()) / dil.daughter(0)->p() / dil.daughter(1)->p();
+  return std::make_pair(cos_angle >= back_to_back_cos_angle_min, cos_angle);
+}
+
+std::pair<bool, CachingVertex<5> > Zprime2muCompositeCandidatePicker_miniAOD::vertex_constrained_fit(const pat::CompositeCandidate& dil) const {
+  // Loose common vertex chi2 cut.
+  assert(dil.numberOfDaughters() == 2);
+  if (abs(dil.daughter(0)->pdgId()) != 13 || abs(dil.daughter(1)->pdgId()) != 13)
+    return std::make_pair(true, CachingVertex<5>()); // pass objects we don't know how to cut on, i.e. e-mu dileptons
+
+  KalmanVertexFitter kvf(true);
+  CachingVertex<5> v = kvf.vertex(get_transient_tracks(dil));
+
+  return std::make_pair(v.isValid() && v.totalChiSquared()/v.degreesOfFreedom() <= vertex_chi2_max, v);
+}
+
+void Zprime2muCompositeCandidatePicker_miniAOD::embed_vertex_constrained_fit(pat::CompositeCandidate& dil, const CachingVertex<5>& vtx) const {
+  if (!vtx.isValid()) {
+    dil.addUserFloat("vertex_chi2", 1e8);
+    return;
+  }
+
+  dil.addUserFloat("vertex_chi2", vtx.totalChiSquared()/vtx.degreesOfFreedom());
+  dil.addUserFloat("vertex_ndof", vtx.degreesOfFreedom());
+  dil.addUserFloat("vertexX", vtx.position().x());
+  dil.addUserFloat("vertexY", vtx.position().y());
+  dil.addUserFloat("vertexZ", vtx.position().z());
+  dil.addUserFloat("vertexXError", sqrt(vtx.error().cxx()));
+  dil.addUserFloat("vertexYError", sqrt(vtx.error().cyy()));
+  dil.addUserFloat("vertexZError", sqrt(vtx.error().czz()));
+
+  InvariantMassFromVertex imfv;
+  static const double muon_mass = 0.1056583;
+  InvariantMassFromVertex::LorentzVector p4 = imfv.p4(vtx, muon_mass);
+  Measurement1D mass = imfv.invariantMass(vtx, muon_mass);
+
+  dil.addUserFloat("vertexPX", p4.X());
+  dil.addUserFloat("vertexPY", p4.Y());
+  dil.addUserFloat("vertexPZ", p4.Z());
+
+  dil.addUserFloat("vertexM",      mass.value());
+  dil.addUserFloat("vertexMError", mass.error());
+}
+
+std::pair<bool, float> Zprime2muCompositeCandidatePicker_miniAOD::dpt_over_pt(const pat::CompositeCandidate& dil) const {
+  // Cut on sigma(pT)/pT to reject grossly mismeasured tracks.
+  float dpt_over_pt_largest = -1.;
+  const size_t n = dil.numberOfDaughters();
+  for (size_t i = 0; i < n; ++i) {
+    // Only apply this cut to muons.
+    if (abs(dil.daughter(i)->pdgId()) == 13) {
+      const reco::CandidateBaseRef& lep = dileptonDaughter(dil, i);
+      if (lep.isNonnull()) {
+	const pat::Muon* mu = toConcretePtr<pat::Muon>(lep);
+	if (mu) {
+	  reco::TrackRef tk = mu->tunePMuonBestTrack();
+          if (!((tk.refCore()).isAvailable())) tk = mu->muonBestTrack();
+	  if ((tk.refCore()).isAvailable()) {
+	    const double dpt_over_pt = tk->ptError()/tk->pt();
+	    if (dpt_over_pt > dpt_over_pt_largest) dpt_over_pt_largest = dpt_over_pt;
+	  }
+	}
+      }
+    }
+  }
+  return std::make_pair(dpt_over_pt_largest < dpt_over_pt_max, dpt_over_pt_largest);
+}
+
+void Zprime2muCompositeCandidatePicker_miniAOD::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Handle<pat::CompositeCandidateCollection> cands;
+  event.getByLabel(src, cands);
+  
+  // does this get cached correctly? do we care?
+  setup.get<TransientTrackRecord>().get("TransientTrackBuilder", ttkb);
+
+  std::auto_ptr<pat::CompositeCandidateCollection> new_cands(new pat::CompositeCandidateCollection);
+
+  // Copy all the candidates that pass the specified cuts into the new
+  // output vector. Also embed into the output dimuons any other
+  // things that are best to just calculate once and for all.
+  for (pat::CompositeCandidateCollection::const_iterator c = cands->begin(), ce = cands->end(); c != ce; ++c) {
+    // Some cuts can be simply specified through the
+    // StringCutSelector.
+    if (!selector(*c))
+      continue;
+   
+    // Now apply cuts that can't.
+
+    // Back-to-back cut to kill cosmics.
+    std::pair<bool, float> cos_angle = back_to_back_cos_angle(*c);
+    if (cut_on_back_to_back_cos_angle && !cos_angle.first)
+      continue;
+
+    // Loose common vertex chi2 cut.
+    std::pair<bool, CachingVertex<5> > vertex = vertex_constrained_fit(*c);
+    if (cut_on_vertex_chi2 && !vertex.first)
+      continue;
+
+    // Loose cut on sigma(pT)/pT of muon tracks.
+    std::pair<bool, float> dpt_over_pt_largest = dpt_over_pt(*c);
+    if (cut_on_dpt_over_pt && !dpt_over_pt_largest.first)
+      continue;
+
+    // Save the dilepton since it passed the cuts, and store the cut
+    // variables and other stuff for use later.
+    new_cands->push_back(*c);
+    new_cands->back().addUserFloat("cos_angle",   cos_angle.second);
+    embed_vertex_constrained_fit(new_cands->back(), vertex.second);
+    new_cands->back().addUserFloat("dpt_over_pt", dpt_over_pt_largest.second);
+  }
+
+  // Sort candidates so we keep either the ones with higher-pT
+  // muons or the ones with larger invariant mass.
+  if(sort_by_pt)
+    sort(new_cands->begin(), new_cands->end(), lepton_pt_sort());
+  else
+    sort(new_cands->begin(), new_cands->end(), reverse_mass_sort());
+
+  // Remove cands of lower invariant mass that are comprised of a
+  // lepton that has been used by a higher invariant mass one.
+  if (do_remove_overlap)
+    remove_overlap(*new_cands);
+
+  // Only return the maximum number of candidates specified.
+  if (new_cands->size() > max_candidates)
+    new_cands->erase(new_cands->begin() + max_candidates, new_cands->end());
+  
+  event.put(new_cands);
+}
+
+DEFINE_FWK_MODULE(Zprime2muCompositeCandidatePicker_miniAOD);

--- a/plugins/Zprime2muLeptonProducer_miniAOD.cc
+++ b/plugins/Zprime2muLeptonProducer_miniAOD.cc
@@ -1,0 +1,387 @@
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/Candidate/interface/CandMatchMap.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/PATUtilities.h"
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/TriggerUtilities.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
+
+class Zprime2muLeptonProducer_miniAOD : public edm::EDProducer {
+public:
+  explicit Zprime2muLeptonProducer_miniAOD(const edm::ParameterSet&);
+
+private:
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+  pat::Electron* cloneAndSwitchElectronEnergy(const pat::Electron&) const;
+  pat::Muon*     cloneAndSwitchMuonTrack     (const pat::Muon&, const edm::Event& event)     const;
+
+  void embedTriggerMatch(pat::Muon*, const std::string&, const pat::TriggerObjectStandAloneCollection&, std::vector<int>&);
+
+  std::pair<pat::Electron*, int> doLepton(const edm::Event&, const pat::Electron&, const reco::CandidateBaseRef&);
+  std::pair<pat::Muon*,     int> doLepton(const edm::Event&, const pat::Muon&,     const reco::CandidateBaseRef&);
+
+  template <typename T> edm::OrphanHandle<std::vector<T> > doLeptons(edm::Event&, const edm::InputTag&, const std::string&);
+
+  edm::InputTag muon_src;
+  edm::InputTag electron_src;
+  StringCutObjectSelector<pat::Muon> muon_selector;
+  StringCutObjectSelector<pat::Electron> electron_selector;
+  std::string muon_track_for_momentum;
+  std::string muon_track_for_momentum_primary;
+  std::vector<std::string> muon_tracks_for_momentum;
+  edm::InputTag muon_photon_match_src;
+  edm::Handle<reco::CandViewMatchMap> muon_photon_match_map;
+  double electron_muon_veto_dR;
+  std::vector<std::pair<float,float> > muon_eta_phis;
+  double trigger_match_max_dR;
+  
+  edm::EDGetTokenT<edm::TriggerResults> triggerBits_;
+  edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> trigger_summary_src_;
+  edm::EDGetTokenT<pat::PackedTriggerPrescales> triggerPrescales_;
+  
+  
+  pat::TriggerObjectStandAloneCollection L3_muons;
+  
+  //std::vector<int> L3_muons_matched;
+  pat::TriggerObjectStandAloneCollection prescaled_L3_muons;
+  //std::vector<int> prescaled_L3_muons_matched;
+  
+  std::vector<int> FilterMatched;
+  std::vector<int> PrescaleFilterMatched;
+};
+
+Zprime2muLeptonProducer_miniAOD::Zprime2muLeptonProducer_miniAOD(const edm::ParameterSet& cfg)
+  : muon_src(cfg.getParameter<edm::InputTag>("muon_src")),
+    electron_src(cfg.getParameter<edm::InputTag>("electron_src")),
+    muon_selector(cfg.getParameter<std::string>("muon_cuts")),
+    electron_selector(cfg.getParameter<std::string>("electron_cuts")),
+    muon_track_for_momentum(cfg.getParameter<std::string>("muon_track_for_momentum")),
+    muon_track_for_momentum_primary(muon_track_for_momentum),
+    muon_photon_match_src(cfg.getParameter<edm::InputTag>("muon_photon_match_src")),
+    electron_muon_veto_dR(cfg.getParameter<double>("electron_muon_veto_dR")),
+    //trigger_summary_src(cfg.getParameter<edm::InputTag>("trigger_summary_src")),
+    trigger_match_max_dR(cfg.getParameter<double>("trigger_match_max_dR")),
+    
+    triggerBits_(consumes<edm::TriggerResults>(cfg.getParameter<edm::InputTag>("bits"))),
+    trigger_summary_src_(consumes<pat::TriggerObjectStandAloneCollection>(cfg.getParameter<edm::InputTag>("trigger_summary"))),
+    triggerPrescales_(consumes<pat::PackedTriggerPrescales>(cfg.getParameter<edm::InputTag>("prescales")))
+{
+  if (cfg.existsAs<std::vector<std::string> >("muon_tracks_for_momentum"))
+    muon_tracks_for_momentum = cfg.getParameter<std::vector<std::string> >("muon_tracks_for_momentum");
+
+  if (muon_tracks_for_momentum.size())
+    for (size_t i = 0; i < muon_tracks_for_momentum.size(); ++i)
+      produces<pat::MuonCollection>(muon_tracks_for_momentum[i]);
+
+  produces<pat::MuonCollection>("muons");
+  produces<pat::ElectronCollection>("electrons");
+}
+
+pat::Electron* Zprime2muLeptonProducer_miniAOD::cloneAndSwitchElectronEnergy(const pat::Electron& electron) const {
+  // HEEP recommendation is to use always the calorimeter energy
+  // instead of the GsfElectron/pat::Electron default, which uses a
+  // weighted combination of the calorimeter and track-fit energy. See
+  // the section "General Comments" at
+  // https://twiki.cern.ch/twiki/bin/view/CMS/HEEPElectronID.
+  pat::Electron* el = electron.clone();
+  el->setP4(electron.p4() * (electron.caloEnergy() / electron.energy()));
+  return el;
+}
+
+pat::Muon* Zprime2muLeptonProducer_miniAOD::cloneAndSwitchMuonTrack(const pat::Muon& muon, const edm::Event& event) const {
+  
+  // Muon mass to make a four-vector out of the new track.
+  
+  
+  
+  pat::Muon* mu = muon.clone();
+  
+  
+  
+  // Start with null track/invalid type before we find the right one.
+  reco::TrackRef newTrack;
+  newTrack = muon.tunePMuonBestTrack();
+
+  
+  if (newTrack.isNull()){
+    std::cout << "No TuneP" << std::endl;
+    return 0;
+    
+  }
+  
+  
+  
+  static const double mass = 0.10566;
+  
+  reco::Particle::Point vtx(newTrack->vx(), newTrack->vy(), newTrack->vz());
+  reco::Particle::LorentzVector p4;
+  
+  const double p = newTrack->p();
+  
+  p4.SetXYZT(newTrack->px(), newTrack->py(), newTrack->pz(), sqrt(p*p + mass*mass));  
+  
+  mu->setCharge(newTrack->charge());
+  
+  mu->setP4(p4);
+  
+  mu->setVertex(vtx);
+  
+  return mu;
+}
+
+
+void Zprime2muLeptonProducer_miniAOD::embedTriggerMatch(pat::Muon* new_mu, const std::string& ex, const pat::TriggerObjectStandAloneCollection& L3, std::vector<int>& L3_matched) {
+  
+  int best = -1;
+  float best_dR = trigger_match_max_dR;
+  for (size_t i = 0; i < L3.size(); ++i) {
+    // Skip those already used.
+    if (L3_matched[i])
+      continue;
+
+    const float dR = reco::deltaR(L3[i], *new_mu);
+    if (dR < best_dR) {
+      best = int(i);
+      best_dR = dR;
+    }
+  }
+
+  if (best < 0)
+    return;
+  
+  const pat::TriggerObjectStandAlone& L3_mu = L3[best];
+  L3_matched[best] = 1;
+  
+  int id = L3_mu.pdgId();
+  new_mu->addUserFloat(ex + "TriggerMatchCharge", -id/abs(id));
+  new_mu->addUserFloat(ex + "TriggerMatchPt",     L3_mu.pt());
+  new_mu->addUserFloat(ex + "TriggerMatchEta",    L3_mu.eta());
+  new_mu->addUserFloat(ex + "TriggerMatchPhi",    L3_mu.phi());
+  
+  
+  
+}
+
+std::pair<pat::Electron*,int> Zprime2muLeptonProducer_miniAOD::doLepton(const edm::Event& event, const pat::Electron& el, const reco::CandidateBaseRef&) {
+  // Electrons can be faked by muons leaving energy in the ECAL. Don't
+  // keep the electron if it's within the dR specified of any global
+  // muon (a la HEEP). Also keep track of the minimum such dR for
+  // embedding in the saved electron.
+  double min_muon_dR = 1e99;
+  for (std::vector<std::pair<float,float> >::const_iterator mu = muon_eta_phis.begin(), end = muon_eta_phis.end(); mu != end; ++mu) {
+    double muon_dR = reco::deltaR(mu->first, mu->second, el.eta(), el.phi());
+    if (muon_dR < min_muon_dR)
+      min_muon_dR = muon_dR;
+
+    if (muon_dR < electron_muon_veto_dR)
+      return std::make_pair((pat::Electron*)(0), -1);
+  }
+
+  // Caller will own this pointer.
+  pat::Electron* new_el = cloneAndSwitchElectronEnergy(el);
+
+  if (new_el == 0)
+    return std::make_pair(new_el, -1);
+
+  // Store the minimum muon dR for later use.
+  new_el->addUserFloat("min_muon_dR", float(min_muon_dR));
+
+  // Evaluate cuts here with string object selector, and any code that
+  // cannot be done in the string object selector (so far, just the
+  // minimum muon dR above).
+  int cutFor = electron_selector(*new_el) ? 0 : 1;
+
+  return std::make_pair(new_el, cutFor);
+}
+
+std::pair<pat::Muon*,int> Zprime2muLeptonProducer_miniAOD::doLepton(const edm::Event& event, const pat::Muon& mu, const reco::CandidateBaseRef& cand) {
+  // Failure is indicated by a null pointer as the first member of the
+  // pair.
+
+  // To use one of the refit tracks, we have to have a global muon.
+  
+    
+  if (!mu.isGlobalMuon())// && mu.pt()<= 20.) // federica
+    return std::make_pair((pat::Muon*)(0), -1);
+
+  // Copy the input muon, and switch its p4/charge/vtx out for that of
+  // the selected refit track.
+  
+  pat::Muon* new_mu = cloneAndSwitchMuonTrack(mu, event);
+
+  if (new_mu == 0){
+    return std::make_pair(new_mu, -1);
+    //std::cout << "Warning" << std::endl;
+  }  
+
+  // Simply store the photon four-vector for now in the muon as a
+  // userData.
+  if (muon_photon_match_map.isValid()) {
+    const reco::CandViewMatchMap& mm = *muon_photon_match_map;
+    if (mm.find(cand) != mm.end()) {
+      new_mu->addUserData<reco::Particle::LorentzVector>("photon_p4", mm[cand]->p4());
+      new_mu->addUserInt("photon_index", mm[cand].key());
+    }    
+  }
+
+  // Do our own trigger matching and embed the results. After the next
+  // pair of function calls, there will be new user floats:
+  // {TriggerMatch, prescaledTriggerMatch} x {Pt, Eta, Phi,
+  // Charge}. (Maybe embed whole candidates later.)
+  
+  embedTriggerMatch(new_mu, "",          L3_muons,           FilterMatched);
+  embedTriggerMatch(new_mu, "prescaled", prescaled_L3_muons, PrescaleFilterMatched);
+
+  // Evaluate cuts here with string object selector, and any code that
+  // cannot be done in the string object selector (none so far).
+  int cutFor = muon_selector(*new_mu) ? 0 : 1;
+
+  return std::make_pair(new_mu, cutFor);
+}
+
+template <typename T>
+edm::OrphanHandle<std::vector<T> > Zprime2muLeptonProducer_miniAOD::doLeptons(edm::Event& event, const edm::InputTag& src, const std::string& instance_label) {
+  typedef std::vector<T> TCollection;
+  edm::Handle<TCollection> leptons; 
+  event.getByLabel(src, leptons); 
+
+  static std::map<std::string, bool> warned;
+  if (!leptons.isValid()) {
+    if (!warned[instance_label]) {
+      edm::LogWarning("LeptonsNotFound") << src << " for " << instance_label << " not found, not producing anything -- not warning any more either.";
+      warned[instance_label] = true;
+    }
+    return edm::OrphanHandle<std::vector<T> >();
+  }
+
+  edm::Handle<reco::CandidateView> lepton_view;
+  event.getByLabel(src, lepton_view);
+
+  std::auto_ptr<TCollection> new_leptons(new TCollection);
+
+  for (size_t i = 0; i < leptons->size(); ++i) {
+    std::pair<T*,int> res = doLepton(event, leptons->at(i), lepton_view->refAt(i));
+    if (res.first == 0)
+      continue;
+    res.first->addUserInt("cutFor", res.second);
+    new_leptons->push_back(*res.first);
+    delete res.first;
+  }
+
+  return event.put(new_leptons, instance_label);
+}
+
+void Zprime2muLeptonProducer_miniAOD::produce(edm::Event& event, const edm::EventSetup& setup) {
+  // Grab the match map between PAT photons and PAT muons so we can
+  // embed the photon candidates later.
+  std::cout << event.id() << std::endl;
+  event.getByLabel(muon_photon_match_src, muon_photon_match_map);
+  static bool warned = false;
+  if (!warned && !muon_photon_match_map.isValid()) {
+    edm::LogWarning("PhotonsNotFound") << muon_photon_match_src << " for photons not found, not trying to embed their matches to muons -- not warning any more either.";
+    warned = true;
+  }
+
+  // Store the L3 muons for trigger match embedding, and clear the
+  // vector of matched flags that indicate whether the particular L3
+  // muon has been used in a match already. This means matching
+  // ambiguities are resolved by original sort order of the
+  // candidates; no attempt is done to find a global best
+  // matching. (This is how it was done in our configuration of the
+  // PATTrigger matcher previously, so why not.) We do this for both
+  // the main path and the prescaled path.
+  
+  Zprime2muTriggerPathsAndFilters pandf(event);
+  if (!pandf.valid)
+    throw cms::Exception("Zprime2muLeptonProducer_miniAOD") << "could not determine the HLT path and filter names for this event\n";
+ 
+
+//TESTING!
+
+    edm::Handle<edm::TriggerResults> triggerBits;
+    edm::Handle<pat::TriggerObjectStandAloneCollection> trigger_summary_src;
+    edm::Handle<pat::PackedTriggerPrescales> triggerPrescales;
+
+    event.getByToken(triggerBits_, triggerBits);
+    event.getByToken(trigger_summary_src_, trigger_summary_src);
+    event.getByToken(triggerPrescales_, triggerPrescales);
+    
+    const edm::TriggerNames &names = event.triggerNames(*triggerBits);
+    
+
+    int j = 0;
+    
+    L3_muons.clear();
+    prescaled_L3_muons.clear();
+    for (pat::TriggerObjectStandAlone obj : *trigger_summary_src) { // note: not "const &" since we want to call unpackPathNames
+        obj.unpackPathNames(names);
+	
+	if (obj.collection() == "hltL3MuonCandidates::HLT"){
+	for (unsigned h = 0; h < obj.filterLabels().size(); ++h) {
+	  
+	  
+	  
+	  if (obj.filterLabels()[h] == "hltL3fL1sMu16orMu25L1f0L2f16QL3Filtered50Q"){ 
+	    //FilterMatched[j] = 1;
+	    L3_muons.push_back(obj);
+	  }  
+	  if (obj.filterLabels()[h] ==	"hltL3fL1sMu16Eta2p1L1f0L2f16QL3Filtered24Q"){
+	    //FilterMatched[j] = 1;
+	    prescaled_L3_muons.push_back(obj);
+	  } 
+	 }
+        }
+	j++;
+    }
+    FilterMatched.clear();
+    FilterMatched.resize(L3_muons.size(), 0);
+    
+    
+    PrescaleFilterMatched.clear();
+    PrescaleFilterMatched.resize(prescaled_L3_muons.size(), 0);
+     
+    
+    // Using the main choice for momentum assignment, make the primary
+    // collection of muons, which will have branch name
+    // e.g. leptons:muons.
+    muon_track_for_momentum = muon_track_for_momentum_primary;
+    edm::OrphanHandle<pat::MuonCollection> muons = doLeptons<pat::Muon>(event, muon_src, "muons");
+
+    // If requested, prepare list of eta,phi coordinates of muons for
+    // vetoing electrons near them.
+    muon_eta_phis.clear();
+    if (electron_muon_veto_dR > 0) {
+      if (!muons.isValid())
+	throw cms::Exception("Zprime2muLeptonProducer_miniAOD") << "requested to veto electrons near muons, but main muon collection is invalid!\n";
+      
+      for (pat::MuonCollection::const_iterator mu = muons->begin(), end = muons->end(); mu != end; ++mu)
+	muon_eta_phis.push_back(std::make_pair(mu->eta(), mu->phi()));
+    }
+    
+    // Now make secondary collections of muons using the momentum
+    // assignments specified. They will come out as e.g. leptons:tpfms,
+    // leptons:picky, ...
+    for (size_t i = 0; i < muon_tracks_for_momentum.size(); ++i) {
+      // Reset the flags so the matching can be redone.
+      FilterMatched.clear();
+      FilterMatched.resize(L3_muons.size(), 0);
+      PrescaleFilterMatched.clear();
+      PrescaleFilterMatched.resize(prescaled_L3_muons.size(), 0);
+      
+      muon_track_for_momentum = muon_tracks_for_momentum[i];
+      doLeptons<pat::Muon>(event, muon_src, muon_track_for_momentum);
+    }
+//
+    // And now make the HEEP electron collection, which will be
+    // e.g. leptons:electrons.
+    doLeptons<pat::Electron>(event, electron_src, "electrons");
+}
+
+DEFINE_FWK_MODULE(Zprime2muLeptonProducer_miniAOD);

--- a/python/HistosFromPAT_cfi.py
+++ b/python/HistosFromPAT_cfi.py
@@ -1,5 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
+HistosFromPAT_miniAOD = cms.EDAnalyzer('Zprime2muHistosFromPAT_miniAOD',
+                               lepton_src = cms.InputTag('leptons', 'muons'),
+                               dilepton_src = cms.InputTag('dimuons'),
+                               leptonsFromDileptons = cms.bool(False),
+                               beamspot_src = cms.InputTag('offlineBeamSpot'),
+                               vertex_src = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                               use_bs_and_pv = cms.bool(True),
+                               useMadgraphWeight = cms.bool(False),
+                               )
+			       
 HistosFromPAT = cms.EDAnalyzer('Zprime2muHistosFromPAT',
                                lepton_src = cms.InputTag('leptons', 'muons'),
                                dilepton_src = cms.InputTag('dimuons'),
@@ -8,4 +18,4 @@ HistosFromPAT = cms.EDAnalyzer('Zprime2muHistosFromPAT',
                                vertex_src = cms.InputTag('offlinePrimaryVertices'),
                                use_bs_and_pv = cms.bool(True),
                                useMadgraphWeight = cms.bool(False),
-                               )
+                               )			       

--- a/python/HistosVertexFromPAT_cfi.py
+++ b/python/HistosVertexFromPAT_cfi.py
@@ -8,3 +8,12 @@ HistosVertexFromPAT = cms.EDAnalyzer('Zprime2muHistosVertexFromPAT',
                                vertex_src = cms.InputTag('offlinePrimaryVertices'),
                                use_bs_and_pv = cms.bool(True),
                                )
+			       
+HistosVertexFromPAT_miniAOD = cms.EDAnalyzer('Zprime2muHistosVertexFromPAT_miniAOD',
+                               lepton_src = cms.InputTag('leptons', 'muons'),
+                               dilepton_src = cms.InputTag('dimuons'),
+                               leptonsFromDileptons = cms.bool(False),
+                               beamspot_src = cms.InputTag('offlineBeamSpot'),
+                               vertex_src = cms.InputTag('offlineSlimmedPrimaryVertices'),
+                               use_bs_and_pv = cms.bool(True),
+                               )			       

--- a/python/MuonPhotonMatch_cff.py
+++ b/python/MuonPhotonMatch_cff.py
@@ -12,5 +12,11 @@ muonPhotonMatch = cms.EDProducer('TrivialDeltaRViewMatcher',
                                  distMin = cms.double(0.1)
                                  )
 
+muonPhotonMatchminiAOD = cms.EDProducer('TrivialDeltaRViewMatcher',
+                                 src     = cms.InputTag('slimmedMuons'),
+                                 matched = cms.InputTag('slimmedPhotons'),
+                                 distMin = cms.double(0.1)
+                                 )
+
 def addUserData(patMuonProducer, tag=cms.InputTag('muonPhotonMatch')):
     patMuonProducer.userData.userCands.src.append(tag)

--- a/python/MuonPhotonMatch_cff_miniAOD.py
+++ b/python/MuonPhotonMatch_cff_miniAOD.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+# JMTBAD muon-photon matching is done here using the default muon
+# momentum and not whichever refit momentum will be eventually used in
+# the analysis. For most muons this shouldn't make much difference as
+# the matching is in eta-phi, but if the default is really bad and the
+# selected refit manages to recover, the photon match may be
+# wrong. The photon brem recovery needs to be studied more anyway.
+muonPhotonMatch = cms.EDProducer('TrivialDeltaRViewMatcher',
+                                 src     = cms.InputTag('slimmedMuons'),
+                                 matched = cms.InputTag('slimmedPhotons'),
+                                 distMin = cms.double(0.1)
+                                 )
+
+def addUserData(patMuonProducer, tag=cms.InputTag('muonPhotonMatch')):
+    patMuonProducer.userData.userCands.src.append(tag)

--- a/python/OurSelectionDec2012_cff.py
+++ b/python/OurSelectionDec2012_cff.py
@@ -59,6 +59,17 @@ allDimuons = cms.EDProducer('Zprime2muCombiner',
                             tight_cut = cms.string(tight_cut)
                             )
 
+dimuons_miniAOD = cms.EDProducer('Zprime2muCompositeCandidatePicker_miniAOD',
+                         src = cms.InputTag('allDimuons'),
+                         cut = cms.string(''),
+                         max_candidates = cms.uint32(1),
+                         sort_by_pt = cms.bool(True),
+                         do_remove_overlap = cms.bool(True),
+                         back_to_back_cos_angle_min = cms.double(-0.9998), # this corresponds to the angle (pi - 0.02) rad = 178.9 deg
+                         vertex_chi2_max = cms.double(20),
+                         dpt_over_pt_max = cms.double(0.3)
+                         )
+			 
 dimuons = cms.EDProducer('Zprime2muCompositeCandidatePicker',
                          src = cms.InputTag('allDimuons'),
                          cut = cms.string(''),
@@ -66,7 +77,6 @@ dimuons = cms.EDProducer('Zprime2muCompositeCandidatePicker',
                          sort_by_pt = cms.bool(True),
                          do_remove_overlap = cms.bool(True),
                          back_to_back_cos_angle_min = cms.double(-0.9998), # this corresponds to the angle (pi - 0.02) rad = 178.9 deg
-#                         vertex_chi2_max = cms.double(10),
                          vertex_chi2_max = cms.double(20),
                          dpt_over_pt_max = cms.double(0.3)
                          )

--- a/python/PATTuple_cfg.py
+++ b/python/PATTuple_cfg.py
@@ -65,7 +65,7 @@ addHEEPId(process)
 
 # PAT taus
 del process.patTaus.tauIDSources.againstElectronMVA5raw
-del process.patTaus.tauIDSources.againstMuonMedium
+#del process.patTaus.tauIDSources.againstMuonMedium
 process.cleanPatTaus.preselection = process.cleanPatTaus.preselection.value().replace('againstMuonMedium', 'againstMuonTight') 
 
 # PAT muons 

--- a/python/SkimMiniAOD_cff.py
+++ b/python/SkimMiniAOD_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from math import fabs
+##process.load('PhysicsTools.PatAlgos.selectionLayer1.muonSelector_cfi')
+from PhysicsTools.PatAlgos.selectionLayer1.muonSelector_cfi import*
+selectedPatMuons.src = cms.InputTag('slimmedMuons')
+selectedPatMuons.cut = cms.string('isGlobalMuon && pt>20.')
+
+def addUserData(patMuonProducer, tag=cms.InputTag('selectedPatMuons')):
+    patMuonProducer.userData.userCands.src.append(tag)

--- a/python/Zprime2muAnalysis_cff_miniAOD.py
+++ b/python/Zprime2muAnalysis_cff_miniAOD.py
@@ -1,0 +1,91 @@
+import FWCore.ParameterSet.Config as cms
+
+# A filter for post-tuple filtering on the goodData results as stored
+# in a TriggerResults object instead of filtering at tuple-making
+# time.
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+goodDataFilter = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone()
+goodDataFilter.TriggerResultsTag = cms.InputTag('TriggerResults', '', 'PAT')
+goodDataFilter.HLTPaths = ['goodDataAll'] # can set to just 'goodDataPrimaryVertexFilter', for example
+#goodDataFilter.HLTPaths = ['goodDataPrimaryVertexFilter']# can set to just 'goodDataPrimaryVertexFilter', for example
+goodDataFilter.andOr = False # = AND
+
+from SkimMiniAOD_cff import selectedPatMuons
+from MuonPhotonMatch_cff_miniAOD import muonPhotonMatch
+from OurSelectionDec2012_cff import allDimuons, dimuons_miniAOD, loose_cut
+
+leptons = cms.EDProducer('Zprime2muLeptonProducer_miniAOD',
+                         muon_src = cms.InputTag('selectedPatMuons'), #JMTBAD changeme after new PAT tuples
+                         electron_src = cms.InputTag('slimmedElectrons'),
+                         muon_cuts = cms.string(loose_cut),
+                         ##muon_cuts = cms.string('isGlobalMuon && pt>20'),
+                         electron_cuts = cms.string('userInt("HEEPId") == 0'),
+                         muon_track_for_momentum = cms.string('TunePNew'),
+                         muon_photon_match_src = cms.InputTag('muonPhotonMatch'),
+                         electron_muon_veto_dR = cms.double(-1),
+                         trigger_match_max_dR = cms.double(0.2),
+                         trigger_summary = cms.InputTag('selectedPatTrigger'),
+			 bits = cms.InputTag("TriggerResults","","HLT"),
+    			 prescales = cms.InputTag("patTrigger"),
+                         )
+
+
+
+Zprime2muAnalysisSequence = cms.Sequence(selectedPatMuons * muonPhotonMatch * leptons * allDimuons * dimuons_miniAOD)
+#Zprime2muAnalysisSequence = cms.Sequence(muonPhotonMatch * leptons * allDimuons * dimuons)
+
+def rec_levels(process, new_track_types):
+    process.leptons.muon_tracks_for_momentum = cms.vstring(*new_track_types)
+    #process.Zprime2muAnalysisSequence = cms.Sequence(process.muonPhotonMatch * process.leptons)
+    #process.Zprime2muAnalysisSequencePlain = cms.Sequence(process.muonPhotonMatch * process.leptons * process.allDimuons * process.dimuons)
+    process.Zprime2muAnalysisSequence = cms.Sequence(process.selectedPatMuons *process.muonPhotonMatch * process.leptons)
+    process.Zprime2muAnalysisSequencePlain = cms.Sequence(process.selectedPatMuons *process.muonPhotonMatch * process.leptons * process.allDimuons * process.dimuons_miniAOD)
+    for t in new_track_types:
+        ad = process.allDimuons.clone()
+        label = 'leptons:%s' % t
+        ad.decay = '%s@+ %s@-' % (label, label)
+        setattr(process, 'allDimuons' + t, ad)
+
+        d = process.dimuons.clone()
+        d.src = 'allDimuons' + t
+        setattr(process, 'dimuons' + t, d)
+
+        process.Zprime2muAnalysisSequence *= ad
+        process.Zprime2muAnalysisSequence *= d
+
+def rec_level_module(process, module, name, tracks):
+    p = []
+    for t in tracks:
+        h = module.clone()
+        if hasattr(h, 'lepton_src'):
+            h.lepton_src = cms.InputTag('leptons', t)
+        if hasattr(h, 'dilepton_src'):
+            h.dilepton_src = cms.InputTag('dimuons' + t)
+        setattr(process, name + t, h)
+        p.append(h)
+    return reduce(lambda x,y: x*y, p)
+
+def switch_to_old_selection(process):
+    # Unfortunate names: what used to be New is now old
+    import OurSelectionNew_cff
+    process.leptons.muon_cuts = OurSelectionNew_cff.loose_cut
+    process.allDimuons = OurSelectionNew_cff.allDimuons
+    process.dimuons = OurSelectionNew_cff.dimuons
+
+def switch_hlt_process_name(process, name):
+    # JMTBAD better place for this fcn
+    class warn_hlt_visitor(object):
+        def enter(self, visitee):
+            for attr in dir(visitee):
+                if str(getattr(visitee, attr)) == 'HLT':
+                    print 'warning: visitee %s, attribute %s has value HLT' % (visitee, attr)
+        def leave(self, visitee):
+            pass
+    from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag
+    for path_name, path in process.paths.iteritems(): # why does values() throw an exception?
+        for label in ['TriggerResults', 'hltL1GtObjectMap', 'TriggerResults']:
+            old = cms.InputTag(label, '', 'HLT')
+            new = cms.InputTag(label, '', name)
+            massSearchReplaceAnyInputTag(path, old, new, verbose=False)
+        path.visit(warn_hlt_visitor())
+                                        

--- a/python/Zprime2muAnalysis_cff_miniAOD.py
+++ b/python/Zprime2muAnalysis_cff_miniAOD.py
@@ -11,7 +11,7 @@ goodDataFilter.HLTPaths = ['goodDataAll'] # can set to just 'goodDataPrimaryVert
 goodDataFilter.andOr = False # = AND
 
 from SkimMiniAOD_cff import selectedPatMuons
-from MuonPhotonMatch_cff_miniAOD import muonPhotonMatch
+from MuonPhotonMatch_cff import muonPhotonMatchminiAOD
 from OurSelectionDec2012_cff import allDimuons, dimuons_miniAOD, loose_cut
 
 leptons = cms.EDProducer('Zprime2muLeptonProducer_miniAOD',
@@ -21,7 +21,7 @@ leptons = cms.EDProducer('Zprime2muLeptonProducer_miniAOD',
                          ##muon_cuts = cms.string('isGlobalMuon && pt>20'),
                          electron_cuts = cms.string('userInt("HEEPId") == 0'),
                          muon_track_for_momentum = cms.string('TunePNew'),
-                         muon_photon_match_src = cms.InputTag('muonPhotonMatch'),
+                         muon_photon_match_src = cms.InputTag('muonPhotonMatchminiAOD'),
                          electron_muon_veto_dR = cms.double(-1),
                          trigger_match_max_dR = cms.double(0.2),
                          trigger_summary = cms.InputTag('selectedPatTrigger'),
@@ -31,7 +31,7 @@ leptons = cms.EDProducer('Zprime2muLeptonProducer_miniAOD',
 
 
 
-Zprime2muAnalysisSequence = cms.Sequence(selectedPatMuons * muonPhotonMatch * leptons * allDimuons * dimuons_miniAOD)
+Zprime2muAnalysisSequence = cms.Sequence(selectedPatMuons * muonPhotonMatchminiAOD * leptons * allDimuons * dimuons_miniAOD)
 #Zprime2muAnalysisSequence = cms.Sequence(muonPhotonMatch * leptons * allDimuons * dimuons)
 
 def rec_levels(process, new_track_types):

--- a/python/Zprime2muAnalysis_cfg.py
+++ b/python/Zprime2muAnalysis_cfg.py
@@ -21,4 +21,8 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 process.GlobalTag.globaltag = 'MCRUN2_74_V9'
 
-process.load('SUSYBSMAnalysis.Zprime2muAnalysis.Zprime2muAnalysis_cff')
+flag = cms.string('miniAOD')
+if flag == 'AOD':
+	process.load('SUSYBSMAnalysis.Zprime2muAnalysis.Zprime2muAnalysis_cff')
+if flag == 'miniAOD':
+	process.load('SUSYBSMAnalysis.Zprime2muAnalysis.Zprime2muAnalysis_cff_miniAOD')

--- a/python/goodData_cff.py
+++ b/python/goodData_cff.py
@@ -10,7 +10,7 @@ hltPhysicsDeclared = cms.EDFilter('HLTPhysicsDeclared',
                                   L1GtReadoutRecordTag = cms.InputTag('gtDigis')
                                   )
 
-primaryVertex = cms.EDFilter('GoodVertexFilter',
+primaryVertexFilter = cms.EDFilter('GoodVertexFilter',
                                    vertexCollection = cms.InputTag('offlinePrimaryVertices'),
                                    minimumNDOF = cms.uint32(4),
                                    maxAbsZ = cms.double(24),

--- a/python/goodData_cff.py
+++ b/python/goodData_cff.py
@@ -10,7 +10,7 @@ hltPhysicsDeclared = cms.EDFilter('HLTPhysicsDeclared',
                                   L1GtReadoutRecordTag = cms.InputTag('gtDigis')
                                   )
 
-primaryVertexFilter = cms.EDFilter('GoodVertexFilter',
+primaryVertex = cms.EDFilter('GoodVertexFilter',
                                    vertexCollection = cms.InputTag('offlinePrimaryVertices'),
                                    minimumNDOF = cms.uint32(4),
                                    maxAbsZ = cms.double(24),


### PR DESCRIPTION
Changes to allow the analysis to be run over miniAOD.

Simply change the flag in the Zprime2muAnalysis_cfg.py file and you can run the analysis and main histogramming modules as normal.
