### PR TITLE
Update N-1 plotting scripts again, add test/NMinus1Effs/nm1entry.py, …

### DIFF
--- a/test/NMinus1Effs/draw.py
+++ b/test/NMinus1Effs/draw.py
@@ -2,587 +2,166 @@
 
 # (py draw.py >! plots/nminus1effs/out.draw) && tlp plots/nminus1effs
 
-from pprint import pprint
-import sys, os
-from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
-set_zp2mu_style()
-ROOT.gStyle.SetPadTopMargin(0.02)
-ROOT.gStyle.SetPadRightMargin(0.02)
-ROOT.gStyle.SetTitleX(0.12)
-#ROOT.gStyle.SetTitleH(0.07)
-ROOT.TH1.AddDirectory(0)
+# Import nm1entry.py
+# - from MCSamples and roottools import *
+# - nm1entry class
+# - eff_wald()
+# - nminus1s list
+# - pretty dictionary
+# - styles dictionary
+from nm1entry import *
 
-outfile = ROOT.TFile("whargl.root","recreate")
-iarp=0
-do_tight = 'tight' in sys.argv
-#psn = 'plots/nminus1effs'
-psn = 'plots/paper2016'
-# 'plots' = '/afs/cern.ch/work/c/cschnaib/NMinus1Effs/plots/TAG/'
-if do_tight:
-    psn += '_tight'
-ps = plot_saver(psn, size=(600,600), log=False, pdf=True)
-ps.c.SetBottomMargin(0.2)
+def draw_test(tag, printStats, lumi, do_tight=False):
+    # Specific stylings for this script on top of zp2mu_style
+    ROOT.gStyle.SetPadTopMargin(0.02)
+    ROOT.gStyle.SetPadRightMargin(0.02)
+    ROOT.gStyle.SetTitleX(0.25)
+    ROOT.gStyle.SetTitleY(0.50)
+    #ROOT.gStyle.SetTitleH(0.07)
+    ROOT.TH1.AddDirectory(0)
+    outfile = ROOT.TFile("whargl.root","recreate")
+    iarp=0
 
+    # 'plots' = '/afs/cern.ch/work/c/cschnaib/Zprime2muAnalysis/NMinus1Effs/plots/TAG/tag'
+    # TAG = MC/Data production TAG
+    # tag = sub tag for each version of plots made with a single production TAG
+    psn = 'plots'
+    if tag:
+        psn = 'plots/%s'%tag
 
-if do_tight:
-    nminus1s = [
-        #'TiPt',
-        'TiDB',
-        'TiGlbChi2',
-        'TiIso',
-        'TiTkLayers',
-        'TiPxHits',
-        'TiMuHits',
-        'TiMuMatch',
+    # cjsbad - fix the referencing to tightnm1...
+    #if do_tight:
+    #    psn += '_tight'
+    #    nminus1s = tightnm1[:]
+
+    ps = plot_saver(psn, size=(600,600), log=False, pdf=True)
+    ps.c.SetBottomMargin(0.2)
+
+    data = nm1entry('data', True, lumi)#lumiCD )
+
+    # 50 < m < 120 GeV
+    samples50m120 = [dy50to120,dy120to200,dy200to400,ttbar_pow,ww_incl,wz,zz_incl,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
+    mc_samples_50m120 = [nm1entry(sample,False,lumi) for sample in samples50m120]
+
+    # m > 120 GeV
+    samples120m = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,wz,zz_incl,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
+    mc_samples_120m = [nm1entry(sample,False,lumi) for sample in samples120m]
+
+    mass_ranges = [
+         ('60m120',(60,120)),
+         ('120m',(120,2500)),
         ]
-else:
-    nminus1s = [
-        'NoPt',
-        'NoDB',
-        'NoIso',
-        'NoTkLayers',
-        'NoPxHits',
-        'NoMuHits',
-        'NoMuMatch',
-        'NoVtxProb',
-        'NoB2B',
-        'NoDptPt',
-                #'NoCosm',
-        'NoTrgMtch',
-        ]
 
-pretty = {
-    'NoPt': 'p_{T} > 53 GeV',
-    'NoTkLayers': '# tk lay > 5',
-    'NoPxHits': '# px hits > 0',
-    'NoMuStns': '# mu segs > 1',
-    'NoDB': '|dxy| < 0.2',
-    'NoGlbChi2': 'glb #chi^{2}/ndf < 10',
-    'NoTkMuon': 'isTrackerMuon',
-    'NoMuHits': '# mu hits > 0',
-    'NoMuMatch': '# matched stations > 1',
-    'NoCosm': 'anti-cosmic',
-    'NoTrgMtch': 'HLT match',
-    'NoB2B': 'back-to-back',
-    'NoVtxProb': '#chi^{2} #mu#mu vtx < 20',
-    'NoDptPt': 'dpT/pT',
-    'NoIso': 'rel. tk. iso.',
-    #'data': 'Data, %.1f fb^{-1}',
-    'data': 'Data, %.1f fb^{-1}, MuonOnly',
-    'dataB': 'Data RunB, %.1f fb^{-1}, MuonOnly',
-    'dataCD': 'Data RunC+D, %.1f fb^{-1}, MuonOnly',
-    'dataBCD': 'Data RunB+C+D, %.1f fb^{-1}, MuonOnly',
-    'mcsum_lumi': 'Simulation',
-    'mcsum_ref': 'Simulation',
-    'mc50m120_lumi': 'Simulation 60 < M < 120 GeV',
-    'mc50m120_ref': 'Simulation 60 < M < 120 GeV',
-    'mc120m_lumi': 'Simulation M > 120 GeV',
-    'mc120m_ref': 'Simulation M > 120 GeV',
-    'mc800m2300_lumi': 'Simulation 800 < M < 2300 GeV',
-    'mc800m2300_ref': 'Simulation 800 < M < 2300 GeV',
-    'mc400m2300_lumi': 'Simulation 400 < M < 2300 GeV',
-    'mc400m2300_ref': 'Simulation 400 < M < 2300 GeV',
-    'zmumu': 'Z#rightarrow#mu#mu, 60 < M < 120 GeV',
-    'dy120_c1': 'DY#rightarrow#mu#mu, M > 120 GeV',
-    'dy200_c1': 'DY#rightarrow#mu#mu, M > 200 GeV',
-    'dy500_c1': 'DY#rightarrow#mu#mu, M > 500 GeV',
-    'dy1000_c1': 'DY#rightarrow#mu#mu, M > 1000 GeV',
-    'dy50': 'DY#rightarrow#mu#mu madgraph',
-#    'dy50': 'DY#rightarrow#mu#mu, M > 50 GeV',
-    'dy50to120': 'DY#rightarrow#mu#mu powheg',
-    'dy50_startup': 'DY#rightarrow#mu#mu startup',
-    'ttbar': 't#bar{t}',
-    'ttbar_pow': 't#bar{t} powheg',
-    'ttbar_startup': 't#bar{t} startup',
-    'ww_incl': 'WW',
-    'zz_incl': 'ZZ',
-    'wz' : 'WZ',
-    'inclmu15': 'QCD',
-    'zssm1000': 'Z\' SSM, M=1000 GeV',
-    'zpsi5000': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_m1TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_1m3TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_3mTeV': 'Z\'_{#psi}, M=5000 GeV',
-    '60m120_BCD': '60 < m < 120 GeV',
-    '60m120_CD': '60 < m < 120 GeV',
-    '60m120': '60 < m < 120 GeV',
-    '60m': 'm > 60 GeV',
-    '70m110': '70 < m < 110 GeV',
-    '120m200': '120 < m < 200 GeV', 
-    '200m400': '200 < m < 400 GeV',
-    '400m600': '400 < m < 600 GeV',
-    '200m': 'm > 200 GeV',
-    '50m': 'm > 50 GeV',
-    '70m': 'm > 70 GeV',
-    '120m_BCD': 'm > 120 GeV',
-    '120m_CD': 'm > 120 GeV',
-    '120m': 'm > 120 GeV',
-    'DY120to200Powheg': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
-    'DY200to400Powheg': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
-    'DY400to800Powheg': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
-    'DY800to1400Powheg': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
-    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
-    '400m800' : '400 < m < 800 GeV',
-    '800m1400': '800 < m < 1400 GeV',
-    '1400m2300':'1400 < m < 2300 GeV',
-    '800m2300':'800 < m < 2300 GeV',
-    '400m2300':'400 < m < 2300 GeV',
-    'all_lumi':'Simulation M > 120 GeV',
-    'all_ref':'Simulation M > 120 GeV',
-    '120m1400':'120 < M < 1400 GeV',
-    }
+    to_use = {
+        '60m120':   [mc_samples_50m120,data],
+        '120m':   [mc_samples_120m,data],
+        }
 
-class nm1entry:
-    def __init__(self, sample, is_data, lumi):
-        if type(sample) == str:
-            self.name = sample
-            self.fn = 'data/ana_nminus1_%s.root' %sample
-            #self.fn = self.make_fn(sample) if is_data else None
-            self.lumi = lumi if is_data else None
-            self.is_data = is_data
-        else:
-            self.name = sample.name
-            self.fn = self.make_fn(self.name)
-            self.partial_weight = sample.partial_weight
-            self.is_data = is_data
-        self.prepare_histos()
-            
+    ymin = {
+        '60m120':  0.7,
+        '120m':    0.5,
+        }
 
-    def make_fn(self, name):
-        '''
-        if self.is_data:
-            return 'data/ana_nminus1_%s.root' % name
-        else:
-        '''
-        return 'mc/ana_nminus1_%s.root' % name
+    #global_ymin = 0.
+    global_ymin = None
+
+
+    for name, mass_range in mass_ranges:
+        pretty_name = pretty[name]
+
+        lg = ROOT.TLegend(0.25, 0.21, 0.91, 0.44)
+        lg.SetTextSize(0.03)
+        lg.SetFillColor(0)
+        lg.SetBorderSize(1)
+        
+        same = 'A'
+        effs = []
+        
+        for entry in to_use[name]:
+
+            l = len(nminus1s)
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                color, fill = styles[entry.name]
+                nminus1_num = ROOT.TH1F('num', '', l, 0, l)
+                nminus1_den = ROOT.TH1F('den', '', l, 0, l)
+                hnum = entry.histos['NoNo']
+                num = get_integral(hnum, *mass_range, integral_only=True, include_last_bin=False, nm1=True)
+                for i,nminus1 in enumerate(nminus1s):
+                    if printStats: table(entry,nminus1, mass_range)
+                    hden = entry.histos[nminus1]
+                    den = get_integral(hden, *mass_range, integral_only=True, include_last_bin=False, nm1=True)
+                    nminus1_num.SetBinContent(i+1, num)
+                    nminus1_den.SetBinContent(i+1, den)
+                eff,ycp,eylcp,eyhcp = binomial_divide(nminus1_num, nminus1_den)
+            else:
+                color = ROOT.kGreen+2
+                fill = 1001
+                nMC = len(entry)
+                num = []
+                pw = []
+                den = []
+                for i, mc in enumerate(entry):
+                    den.append([])
+                    hnum = mc.histos['NoNo']
+                    num.append(get_integral(hnum, *mass_range, integral_only=True, include_last_bin=False, nm1=True))
+                    pw.append(mc.partial_weight * lumi)
+                    for j, nminus1 in enumerate(nminus1s):
+                        if printStats: table_wald(mc,nminus1, mass_range)
+                        hden = mc.histos[nminus1]
+                        den[i].append(get_integral(hden, *mass_range, integral_only=True, include_last_bin=False, nm1=True))
+                nm1Temp = ROOT.TH1F('temp','',l,0,l)
+                eff,y,eyl,eyh = eff_wald(num, den, l, nMC, pw, nm1Temp)
+            eff.SetTitle(pretty_name)
+            eff.GetYaxis().SetRangeUser(global_ymin if global_ymin is not None else ymin[name], 1.01)
+            eff.GetXaxis().SetTitle('cut')
+            eff.GetYaxis().SetLabelSize(0.027)
+            eff.GetYaxis().SetTitle('n-1 efficiency')
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                draw = 'P'
+                eff.SetLineColor(color)
+                eff.SetMarkerStyle(20)
+                eff.SetMarkerSize(1.05)
+                eff.SetMarkerColor(color)
+                #lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
+                lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
+            else:
+                draw = '2'
+                eff.SetLineColor(color)
+                eff.SetFillColor(color)
+                eff.SetFillStyle(fill)
+                #lg.AddEntry(eff, pretty.get(entry.name, entry.name), 'LF')
+                lg.AddEntry(eff, 'Simulation', 'LF')
+            draw += same
+            eff.Draw(draw)
+            effs.append(eff)
+            same = ' same'
+            bnr = eff.GetXaxis().GetNbins()/float(eff.GetN()+1)
+            for i, n in enumerate(nminus1s):
+                eff.GetXaxis().SetBinLabel(int((i+0.5)*bnr), pretty.get(n,n))
+            eff.GetXaxis().LabelsOption('v')
+            outfile.cd()
+            eff.Write("arp%d"%iarp)
+            iarp+=1
+
+        lg.Draw()
+        ps.save(name)
+        print(name, pretty_name)
+
+# ************************************************************************
+# Main
+# ************************************************************************
+if __name__=='__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='submits limits for a given mass')
+    parser.add_argument('--tag',help='Tagged directory name for input histograms and output plots',default='')
+    parser.add_argument('--stats',help='Print stats',default=False)
+    parser.add_argument('--lumi',help='Integrated luminosity in pb-1',default='1000')
+    parser.add_argument('--do_tight',help='Do tight cuts',default=False)
+    args = parser.parse_args()
     
-    def prepare_histos(self):
-        self.histos = {}
-        if self.fn is not None:
-            f = ROOT.TFile(self.fn)
-            for nminus1 in nminus1s + ['NoNo']:
-                if nminus1=='NoVtxProb':
-                    self.histos[nminus1] = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()#DileptonMass
+    tag = args.tag
+    if not os.path.exists('plots/%s'%tag):
+        raise ValueError('Tagged directory %s does not exist!'%tag)
 
-    def prepare_histos_sum(self, samples, lumi):
-        self.histos = {}
-        for nminus1 in nminus1s + ['NoNo']:
-            hs = []
-            #print '%20s%20s%21s%20s%20s' % ('cut', 'sampe name', 'partial weight', 'scale(ref)','scale(lumi)')
-            for sample in samples:
-                f = ROOT.TFile(self.make_fn(sample.name))
-                if nminus1 == 'NoVtxProb':
-                    h = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
-                #print '%20s%20s%20.15f%20f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS, lumiBCD)
-                # partial_weight = cross_section * k_factor / Nevents
-                if lumi>0:
-                    # scale to luminosity for comparision of single dataset to MC
-                    h.Scale(sample.partial_weight * lumi) 
-                    #print nminus1, sample.name, sample.partial_weight*lumi
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, lumi)
-                if lumi<0:
-                    # scale to reference cross section/Nevents for comparision of multiple datasets to MC
-                    h.Scale(sample.partial_weight * refN / refXS)  
-                    #print nminus1, sample.name, sample.partial_weight*refN/refXS
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS)
-                hs.append(h)
-            hsum = hs[0].Clone()
-            for h in hs[1:]:
-                hsum.Add(h)
-            self.histos[nminus1] = hsum
+    draw_test(tag, args.stats, float(args.lumi), args.do_tight)
 
-#data, lumi = nm1entry('data', True), 242.8 # lumi in pb
-nolumi = -1
-lumiB = 50.7 
-lumiCD = 2619.44
-lumiD = 2572.19
-#lumiBCD = 2660.14
-lumiBCD = 2800.
-#dataB = nm1entry('dataB', True, lumiB)#lumiB )
-#dataCD = nm1entry('dataCD', True, lumiCD)#lumiCD )
-dataBCD = nm1entry('dataBCD', True, lumiBCD)#lumiCD )
-#dataD = nm1entry('dataD', True, lumiD )
-#mcsum_lumi = nm1entry('mcsum_lumi',False,lumiBCD)
-#mcsum_ref = nm1entry('mcsum_ref',False,nolumi)
-#mc50m_lumi = nm1entry('mc50m_lumi',False,lumiBCD)
-#mc50m_ref = nm1entry('mc50m_ref',False,nolumi)
-#mc50m120_lumi = nm1entry('mc50m120_lumi',False,lumiBCD)
-#mc50m120_ref = nm1entry('mc50m120_ref',False,nolumi)
-#mc120m_lumi = nm1entry('mc120m_lumi',False,lumiBCD)
-#mc120m_ref = nm1entry('mc120m_ref',False,nolumi)
-#mc800m2300_lumi = nm1entry('mc800m2300_lumi',False,lumiCD)
-#mc800m2300_ref = nm1entry('mc800m2300_ref',False,nolumi)
-#mc400m2300_lumi = nm1entry('mc400m2300_lumi',False,lumiCD)
-#mc400m2300_ref = nm1entry('mc400m2300_ref',False,nolumi)
-
-from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
-# old startup alignment
-#raw_samples = [dy50to120,DY120to200Powheg,DY200to400Powheg,DY400to800Powheg,DY800to1400Powheg,dy1400to2300,dy2300to3500,DY3500to4500Powheg,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,wjets,inclmu15,zpsi5000,qcd50to80,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]
-#raw_samples = [dy50to120,DY120to200Powheg,DY200to400Powheg,DY400to800Powheg,DY800to1400Powheg,dy1400to2300,dy2300to3500,DY3500to4500Powheg,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,zpsi5000]
-#raw_samples50m120 = [dy50to120,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,wjets,qcd50to80,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#,inclmu15]
-#raw_samples120m = [DY120to200Powheg,DY200to400Powheg,DY400to800Powheg,DY800to1400Powheg,dy2300to3500,DY3500to4500Powheg,dy4500to6000,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,wjets,qcd50to80,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#inclmu15
-#qcd120to170,qcd600to800
-# new startup alignment
-
-#raw_samples = [dy50to120_s,dy120to200_s,dy200to400_s,dy400to800_s,dy800to1400_s,dy1400to2300_s,dy2300to3500_s,dy3500to4500_s,dy4500to6000_s,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,wjets,inclmu15,zpsi5000,qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#,dy6000_s
-#raw_samples50m120 = [dy50to120_s,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#,inclmu15],dy6000_s
-#raw_samples120m = [dy120to200_s,dy200to400_s,dy400to800_s,dy800to1400_s,dy1400to2300_s,dy2300to3500_s,dy3500to4500_s,dy4500to6000_s,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#inclmu15
-
-raw_samples50m120 = [dy50to120,dy120to200,dy200to400,ttbar_pow,ww_incl,wz,zz_incl,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
-raw_samples120m = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,wz,zz_incl,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
-
-#raw_samples800m2300 = [dy800to1400_s,dy1400to2300,ttbar_pow]
-#raw_samples400m2300 = [dy400to800_s,dy800to1400_s,dy1400to2300,ttbar_pow]
-
-#raw_samples = [dy50to120, ttbar_pow]
-#raw_samples = [dy50, ttbar, ww_incl, zz_incl, wz, dy50to120, ttbar_pow, dy50_startup, ttbar_startup]
-#raw_samples = [zmumu, dy120_c1, dy200_c1, dy500_c1, dy1000_c1, ttbar, inclmu15]
-
-# All MC samples
-# lumi
-#mcsum_lumi.prepare_histos_sum(raw_samples,lumiCD)
-#mc_samples_sum_lumi = [nm1entry(sample,False,lumiBCD) for sample in raw_samples]
-#for mc_sample in mc_samples_sum_lumi:
-#    exec '%s = mc_sample' % mc_sample.name
-# ref
-#mcsum_ref.prepare_histos_sum(raw_samples, nolumi) 
-#mc_samples_sum_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples]
-#for mc_sample in mc_samples_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-#
-# m > 50 GeV
-# lumi
-#mc50m_lumi.prepare_histos_sum(raw_samples50m, lumiBCD)
-#mc_samples_50m_lumi = [nm1entry(sample,False,lumiBCD) for sample in raw_samples50m]
-#for mc_sample in mc_samples_50m_lumi:
-#    exec '%s = mc_sample' % mc_sample.name
-# ref
-#mc50m_ref.prepare_histos_sum(raw_samples50m, nolumi)
-#mc_samples_50m_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples50m]
-#for mc_sample in mc_samples_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-#
-# 50 < m < 120 GeV
-# lumi
-#mc50m120_lumi.prepare_histos_sum(raw_samples50m120, lumiBCD)
-mc_samples_50m120 = [nm1entry(sample,False,lumiBCD) for sample in raw_samples50m120]
-for mc_sample in mc_samples_50m120:
-    exec '%s = mc_sample' % mc_sample.name
-# ref
-#mc50m120_ref.prepare_histos_sum(raw_samples50m120, nolumi)
-#mc_samples_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples50m120]
-#for mc_sample in mc_samples_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-#
-# M > 120 GeV
-# lumi
-#mc120m_lumi.prepare_histos_sum(raw_samples120m, lumiBCD)
-mc_samples_120m = [nm1entry(sample,False,lumiBCD) for sample in raw_samples120m]
-for mc_sample in mc_samples_120m:
-    exec '%s = mc_sample' % mc_sample.name
-# ref
-#mc120m_ref.prepare_histos_sum(raw_samples120m, nolumi)
-#mc_samples120m_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples120m]
-#for mc_sample in mc_samples120m_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-
-## 800 < m < 2300 GeV
-## lumi
-#mc800m2300_lumi.prepare_histos_sum(raw_samples800m2300, lumiCD)
-#mc_samples800m2300_lumi = [nm1entry(sample,False,lumiCD) for sample in raw_samples800m2300]
-#for mc_sample in mc_samples800m2300_lumi:
-#    exec '%s = mc_sample' % mc_sample.name
-## ref
-#mc800m2300_ref.prepare_histos_sum(raw_samples800m2300, nolumi)
-#mc_samples800m2300_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples800m2300]
-#for mc_sample in mc_samples800m2300_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-#
-## 400 < m < 2300 GeV
-## lumi
-#mc400m2300_lumi.prepare_histos_sum(raw_samples400m2300, lumiCD)
-#mc_samples800m2300_lumi = [nm1entry(sample,False,lumiCD) for sample in raw_samples800m2300]
-#for mc_sample in mc_samples800m2300_lumi:
-#    exec '%s = mc_sample' % mc_sample.name
-## ref 
-#mc400m2300_ref.prepare_histos_sum(raw_samples400m2300, nolumi)
-#mc_samples800m2300_ref = [nm1entry(sample,False,nolumi) for sample in raw_samples800m2300]
-#for mc_sample in mc_samples800m2300_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-#
-mass_ranges = [
-#    ('50m',    (50, 1e9)),
-#    ('70m',    (70, 1e9)),
-#    ('70m110',  ( 70, 110)),
-#    ('200m',    (200, 1e9)),
-#    ('120m_BCD',   (120, 1e9)),
-#    ('120m_CD',   (120, 1e9)),
-#    ('60m120_BCD',  ( 60, 120)),
-#    ('60m120_CD',  ( 60, 120)),
-#    ('120m200', (120, 200)),
-#    ('200m400', (200, 400)),
-#    ('400m800', (400, 800)),
-#    ('800m1400',(800, 1400)),
-#    ('120m1400',(120,1400)),
-#    ('all_lumi',  ( 120, 1e9)),
-#    ('all_ref',  ( 120, 1e9)),
-#    ('1400m2300',(1400, 2300)),
-#    ('800m2300', (800,2300)),
-#    ('400m2300', (400,2300)),
-#    ('zpsi5000',(0,1e9)),
-#    ('zpsi5000_m1TeV',(0,1e3)),
-#    ('zpsi5000_1m3TeV',(1e3,3e3)),
-#    ('zpsi5000_3mTeV',(3e3,1e9)),
-     ('60m120',(60,120)),
-#     ('60m',(60,2000)),
-     ('120m',(120,2500)),
-    ]
-
-to_use = {
-    
-#    '60m120':  [data, dy50to120, dy50],#mcsum], #, zmumu, ttbar],
-#    '70m110':  [data, dy50to120, ttbar_pow, mcsum],
-#    '60m120':  [dataCD, mc50m120_lumi], #, zmumu, ttbar],
-#    '120m200': [data, mcsum, dy50, ttbar, ww_incl, zz_incl, wz],#mcsum], #, dy120_c1, ttbar],
-#    '200m400': [data, mcsum], #, dy200_c1, ttbar],
-#    '400m600': [data, mcsum], #, dy200_c1, ttbar],
-#    '200m':    [data, mcsum, dy50, ttbar, ww_incl, zz_incl, wz],#mcsum], #, dy500_c1, ttbar],
-#    '50m':    [data, dy50to120],
-#    '70m':    [data, dy50to120]
-#    '120m_BCD':   [dataB,dataCD,mc120m_ref],
-#    '120m':   [dataCD,mc120m_lumi],
-#    '60m120':   [dataCD,mc50m120_lumi],
-#    '60m120':   [dataBCD,mc_samples_50m120_lumi],
-    '60m120':   [mc_samples_50m120,dataBCD],
-#    '60m':      [dataCD,mc50m_lumi],
-#    '120m':   [dataCD,mc120m_ref],
-#    '120m':   [dataBCD,mc_samples_120m_lumi],
-    '120m':   [mc_samples_120m,dataBCD],
-#    '60m120':   [dataCD,mc50m120_ref],
-#    '60m120_BCD':  [dataB,dataCD, mc50m120_ref], #, zmumu, ttbar],#powheg
-#    'all_lumi': [dataCD,mc120m_lumi],
-#    'all_ref': [dataCD,mc120m_ref],
-#    '60m120_CD':  [dataCD, dy50to120,ttbar_pow],#mc50m120_lumi, zmumu, ttbar],#powheg
-#    '120m200': [dataCD,DY120to200Powheg],
-#    '200m400': [dataCD,DY200to400Powheg],
-#    '400m800': [dataCD,DY400to800Powheg],
-#    '800m1400': [dataCD,DY800to1400Powheg],
-#    '1400m2300': [dataCD,dy1400to2300], # dataB,dataCD have no events and returns errors?
-#    '800m2300': [dataCD,mc800m2300_lumi],
-#    '400m2300': [dataCD,mc400m2300_lumi],
-#    'zpsi5000':[zpsi5000],
-#    'zpsi5000_m1TeV':[zpsi5000],
-#    'zpsi5000_1m3TeV':[zpsi5000],
-#    'zpsi5000_3mTeV':[zpsi5000],
-    }
-
-styles = {
-#    'data':      (ROOT.kBlack,     -1),
-    'dataB':      (ROOT.kBlack,     -1),
-    'dataCD':      (ROOT.kBlack,     -1),
-    'dataBCD':      (ROOT.kBlack,     -1),
-#    'zmumu':     (ROOT.kRed,     3001),
-#    'dy50':      (ROOT.kBlue,     1001),
-#    'dy50_startup':      (ROOT.kViolet+2,     3001),
-#    'dy200_c1':  (ROOT.kRed,     1001),
-#    'dy500_c1':  (ROOT.kRed,     1001),
-#    'dy1000_c1': (ROOT.kBlue,    1001),
-#    'ttbar':     (ROOT.kGreen+2, 3005),
-#    'ttbar_startup':     (ROOT.kGreen+2, 3005),
-#    'ww_incl':    (ROOT.kBlue,    3004),
-#    'zz_incl':    (62,            3006),
-#    'wz' :       (64,            3007),
-#    'inclmu15':  (28,            3002),
-    'mc50m120_lumi':     (ROOT.kGreen+2, 1001),
-    'mc50m120_ref':     (ROOT.kGreen+2, 1001),
-    'mc50m_lumi':     (ROOT.kGreen+2, 1001),
-    'mc50m_ref':     (ROOT.kGreen+2, 1001),
-    'mc120m_lumi':     (ROOT.kGreen+2, 1001),
-    'mc120m_ref':     (ROOT.kGreen+2, 1001),
-    'mc800m2300_lumi':     (ROOT.kGreen+2, 1001),
-    'mc800m2300_ref':     (ROOT.kGreen+2, 1001),
-    'mc400m2300_lumi':     (ROOT.kGreen+2, 1001),
-    'mc400m2300_ref':     (ROOT.kGreen+2, 1001),
-    'dy50to120':      (ROOT.kGreen+2,     1001),
-    'DY120to200Powheg':  (ROOT.kGreen+2, 1001),
-    'DY200to400Powheg':  (ROOT.kGreen+2, 1001),
-    'DY400to800Powheg':  (ROOT.kGreen+2, 1001),
-    'DY800to1400Powheg': (ROOT.kGreen+2, 1001),
-    'dy1400to2300':      (ROOT.kGreen+2, 1001),
-    'ttbar_pow':     (ROOT.kGreen+2, 1001),
-    'mcsum_lumi':    (ROOT.kGreen+2, 1001),
-    'mcsum_ref':    (ROOT.kGreen+2, 1001),
-    'zpsi5000':    (ROOT.kBlue, 1001),
-    'zpsi5000_m1TeV':    (ROOT.kBlue, 1001),
-    'zpsi5000_1m3TeV':    (ROOT.kBlue, 1001),
-    'zpsi5000_3mTeV':    (ROOT.kBlue, 1001),
-    'mc_samples_50m120': (ROOT.kGreen+2,1001),
-    'mc_samples_120m': (ROOT.kGreen+2,1001),
-    }
-
-ymin = {
-#    '70m110':  0.8,
-#    '120m200': 0.6,
-#    '200m400': 0.85,
-#    '200m':    0.6,
-#    '50m':    0.6,
-#    '70m':    0.6,
-#    '60m120_CD':  0.8,
-    '60m':  0.6,
-    '60m120':  0.7,
-#    '60m120_BCD':  0.8,
-#    '120m_BCD':    0.5,
-#    '120m_CD':    0.5,
-    '120m':    0.5,
-    '120m200': 0.5,
-    '200m400': 0.5,
-    '400m800': 0.5,
-    '800m1400': 0.5,
-    'all_lumi':0.5,
-    'all_ref':0.5,
-    'zpsi5000':0.9,
-    'zpsi5000_m1TeV':0.9,
-    'zpsi5000_1m3TeV':0.9,
-    'zpsi5000_3mTeV':0.9,
-#    '120m1400':0.5,
-#    '1400m2300':0.5,
-#    '800m2300': 0.5,
-#    '400m2300': 0.5,
-    }
-#global_ymin = 0.
-global_ymin = None
-
-
-def table_wald(entry, mass_range):
-    print entry.name
-    hnum = entry.histos['NoNo']
-    mlo, mhi = mass_range
-    num = get_integral(hnum, mlo, mhi, integral_only=True, include_last_bin=False)
-    print 'mass range %5i-%5i:' % mass_range
-    print 'numerator:', num
-    print '%20s%20s%21s%25s%26s' % ('cut', 'denominator', 'efficiency', '- 68% CL-CP +','68% CL-Wald')
-    for nminus1 in nminus1s:
-        hden = entry.histos[nminus1]
-        den = get_integral(hden, mlo, mhi, integral_only=True, include_last_bin=False)
-        if num==0 and den==0:
-            eff = 0
-            errw = 0
-        else:
-            eff = float(num)/den
-            errw = wald_binomial_err2(eff, 1, den)**0.5
-        ecp,lcp,hcp = clopper_pearson(num, den)
-        print '%20s%20f%20f%15f%15f%23f' % (nminus1, den, eff, eff-lcp, hcp-eff, errw)
-        print '%20s%20f%20f%15f%15f%15f%16f' % (nminus1, den, eff, lcp, hcp, eff-errw, eff+errw)
-        print ' '
-    print '---------------------------------------------'
-
-def print_wald_eff(y,eyl,eyh):
-    print 'MC Sum'
-    for i,nminus1 in enumerate(nminus1s):
-        print nminus1, y[i], eyl[i], eyh[i]
-
-def table(entry, mass_range):
-    print entry.name
-    hnum = entry.histos['NoNo']
-    mlo, mhi = mass_range
-    num = get_integral(hnum, mlo, mhi, integral_only=True, include_last_bin=False)
-    print 'mass range %5i-%5i:' % mass_range
-    print 'numerator:', num
-    print '%20s%20s%21s%21s' % ('cut', 'denominator', 'efficiency', '68% CL')
-    for nminus1 in nminus1s:
-        hden = entry.histos[nminus1]
-        den = get_integral(hden, mlo, mhi, integral_only=True, include_last_bin=False)
-        e,l,h = clopper_pearson(num, den)
-        print '%20s%20f%20f%15f%15f' % (nminus1, den, e, e-l, h-e)
-
-ROOT.gStyle.SetTitleX(0.25)
-ROOT.gStyle.SetTitleY(0.50)
-
-for name, mass_range in mass_ranges:
-    pretty_name = pretty[name]
-    print name, pretty_name
-
-    lg = ROOT.TLegend(0.25, 0.21, 0.91, 0.44)
-    lg.SetTextSize(0.03)
-    lg.SetFillColor(0)
-    lg.SetBorderSize(1)
-    
-    same = 'A'
-    effs = []
-    
-    for entry in to_use[name]:
-
-        l = len(nminus1s)
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            table(entry, mass_range)
-            color, fill = styles[entry.name]
-            nminus1_num = ROOT.TH1F('num', '', l, 0, l)
-            nminus1_den = ROOT.TH1F('den', '', l, 0, l)
-            hnum = entry.histos['NoNo']
-            num = get_integral(hnum, *mass_range, integral_only=True, include_last_bin=False)
-            for i,nminus1 in enumerate(nminus1s):
-                hden = entry.histos[nminus1]
-                den = get_integral(hden, *mass_range, integral_only=True, include_last_bin=False)
-                nminus1_num.SetBinContent(i+1, num)
-                nminus1_den.SetBinContent(i+1, den)
-            eff,ycp,eylcp,eyhcp = binomial_divide(nminus1_num, nminus1_den)
-        else:
-            color = ROOT.kGreen+2
-            fill = 1001
-            nMC = len(entry)
-            num = []
-            pw = []
-            den = []
-            for i, mc in enumerate(entry):
-                #table_wald(mc, mass_range)
-                den.append([])
-                hnum = mc.histos['NoNo']
-                num.append(get_integral(hnum, *mass_range, integral_only=True, include_last_bin=False))
-                pw.append(mc.partial_weight * lumiCD)
-                for j, nminus1 in enumerate(nminus1s):
-                    hden = mc.histos[nminus1]
-                    den[i].append(get_integral(hden, *mass_range, integral_only=True, include_last_bin=False))
-                    #if den[i][j]==0 and num[i]==0:
-                    #    print mc.name, nminus1
-            nm1Temp = ROOT.TH1F('temp','',l,0,l)
-            eff,y,eyl,eyh = eff_wald(num, den, l, nMC, pw, nm1Temp)
-            print_wald_eff(y,eyl,eyh)
-        eff.SetTitle(pretty_name)
-        eff.GetYaxis().SetRangeUser(global_ymin if global_ymin is not None else ymin[name], 1.01)
-        eff.GetXaxis().SetTitle('cut')
-        eff.GetYaxis().SetLabelSize(0.027)
-        eff.GetYaxis().SetTitle('n-1 efficiency')
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            draw = 'P'
-            eff.SetLineColor(color)
-            eff.SetMarkerStyle(20)
-            eff.SetMarkerSize(1.05)
-            eff.SetMarkerColor(color)
-            #lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
-            lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
-        else:
-            draw = '2'
-            eff.SetLineColor(color)
-            eff.SetFillColor(color)
-            eff.SetFillStyle(fill)
-            #lg.AddEntry(eff, pretty.get(entry.name, entry.name), 'LF')
-            lg.AddEntry(eff, 'Simulation', 'LF')
-        draw += same
-        eff.Draw(draw)
-        effs.append(eff)
-        same = ' same'
-        bnr = eff.GetXaxis().GetNbins()/float(eff.GetN()+1)
-        for i, n in enumerate(nminus1s):
-            eff.GetXaxis().SetBinLabel(int((i+0.5)*bnr), pretty.get(n,n))
-        eff.GetXaxis().LabelsOption('v')
-        outfile.cd()
-        eff.Write("arp%d"%iarp)
-        iarp+=1
-
-    lg.Draw()
-    ps.save(name)
-    print

--- a/test/NMinus1Effs/draw_bckg_pct.py
+++ b/test/NMinus1Effs/draw_bckg_pct.py
@@ -1,247 +1,148 @@
 #!/usr/bin/env python
 
-from pprint import pprint
-import os,sys
-from array import array
-import numpy as np
-from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
-set_zp2mu_style()
-ROOT.gStyle.SetPadRightMargin(0.03)
-ROOT.gStyle.SetPadLeftMargin(0.12)
-ROOT.gStyle.SetPadTopMargin(0.07)
-ROOT.gStyle.SetTitleBorderSize(0)
-ROOT.TH1.AddDirectory(0)
-outfile = ROOT.TFile("test.root","recreate")
+# Import nm1entry.py
+# - from MCSamples and roottools import *
+# - nm1entry class
+# - nminus1s list
+# - pretty dictionary
+# - styles dictionary
+from nm1entry import *
+ROOT.gROOT.SetBatch(True)
 
+def draw_bckg_pct_test(tag, printStats, lumi):
 
-psn = 'plots/paper2016'
-ps = plot_saver(psn, size=(600,600), log=True, pdf=True, name='bckg_plot')
+    # Specific stylings for this script on top of zp2mu_style
+    ROOT.gStyle.SetPadRightMargin(0.03)
+    ROOT.gStyle.SetPadLeftMargin(0.12)
+    ROOT.gStyle.SetPadTopMargin(0.07)
+    ROOT.gStyle.SetTitleBorderSize(0)
+    ROOT.TH1.AddDirectory(0)
+    # output (find a cmd-line way for psn)
+    outfile = ROOT.TFile("test.root","recreate")
 
-nminus1s = [
-    'NoPt',
-    'NoDB',
-    'NoIso',
-    'NoTkLayers',
-    'NoPxHits',
-    'NoMuHits',
-    'NoMuMatch',
-    'NoVtxProb',
-    'NoB2B',
-    'NoDptPt',
-    #'NoCosm',
-    'NoTrgMtch',
-    'NoNo'
-    ]
+    # 'plots' = '/afs/cern.ch/work/c/cschnaib/Zprime2muAnalysis/NMinus1Effs/plots/TAG/tag'
+    # TAG = MC/Data production TAG
+    # tag = sub tag for each version of plots made with a single production TAG
+    psn = 'plots'
+    if tag:
+        psn = 'plots/%s'%tag
+    ps = plot_saver(psn, size=(600,600), log=True, pdf=True, name='bckg_plot')
 
-pretty = {
-    'NoNo': 'All Selection',
-    'NoPt': 'No p_{T} > 53 GeV',
-    'NoDB': 'No |dxy| < 0.2',
-    'NoIso': 'No rel. tk. iso.',
-    'NoTkLayers': 'No # tk lay > 5',
-    'NoPxHits': 'No # px hits > 0',
-    'NoMuHits': 'No # mu hits > 0',
-    'NoMuMatch': 'No # matched stations > 1',
-    'NoVtxProb': 'No #chi^{2} #mu#mu vtx < 20',
-    'NoB2B': 'No back-to-back',
-    'NoDptPt': 'No dpT/pT',
-    'NoTrgMtch': 'No HLT match',
-    'ttbar_pow': 't#bar{t} powheg',
-    'ww_incl': 'WW',
-    'zz_incl': 'ZZ',
-    'wz' : 'WZ',
-    'dy50to120': 'DY#rightarrow#mu#mu 50 < m < 120 GeV',
-    'dy120to200': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
-    'dy200to400': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
-    'dy400to800': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
-    'dy800to1400': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
-    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
-    'dy2300to3500': 'DY#rightarrow#mu#mu 2300 < m < 3500 GeV',
-    'dy3500to4500': 'DY#rightarrow#mu#mu 3500 < m < 4500 GeV',
-    'dy4500to6000': 'DY#rightarrow#mu#mu 4500 < m < 6000 GeV',
-    'tWtop': 'tW^{-}',
-    'tWantitop': '#bar{t}W^{+}',
-    'wjets': 'W + jets',
-    'qcd80to120': 'QCD 80 < p_{T}(#mu) < 120 GeV',
-    'qcd120to170': 'QCD 120 < p_{T}(#mu) < 170 GeV',
-    'qcd170to300': 'QCD 170 < p_{T}(#mu) < 300 GeV',
-    'qcd300to470': 'QCD 300 < p_{T}(#mu) < 470 GeV',
-    'qcd470to600': 'QCD 470 < p_{T}(#mu) < 600 GeV',
-    'qcd600to800': 'QCD 600 < p_{T}(#mu) < 800 GeV',
-    'qcd800to1000': 'QCD 800 < p_{T}(#mu) < 1000 GeV',
-    'qcd1000to1400': 'QCD 1000 < p_{T}(#mu) < 1400 GeV',
-    'qcd1400to1800': 'QCD 1400 < p_{T}(#mu) < 1800 GeV',
-    'qcd1800to2400': 'QCD 1800 < p_{T}(#mu) < 2400 GeV',
-    'qcd2400to3200': 'QCD 2400 < p_{T}(#mu) < 3200 GeV',
-    'qcd3200': 'QCD p_{T}(#mu) < 3200 GeV',
-}
+    samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
+    mc_samples = [nm1entry(sample,False,lumi) for sample in reversed(samples)]
+    for mc_sample in mc_samples:
+        exec '%s = mc_sample' % mc_sample.name
 
-class nm1entry:
-    def __init__(self, sample, is_data, lumi):
-        if type(sample) == str:
-            self.name = sample
-            self.fn = self.make_fn(sample,is_data) if is_data else None
-            self.lumi = lumi if is_data else None
-        else:
-            self.name = sample.name
-            self.fn = self.make_fn(self.name,is_data)
-            self.partial_weight = sample.partial_weight
-        self.prepare_histos()
-            
-    def make_fn(self, name, is_data):
-        if is_data==True:
-            return 'data/ana_nminus1_%s.root' %name
-        else:
-            return 'mc/ana_nminus1_%s.root' % name
-    
-    def prepare_histos(self):
-        self.histos = {}
-        if self.fn is not None:
-            f = ROOT.TFile(self.fn)
-            for nminus1 in nminus1s:
-                self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()#DileptonMass
+    # Include 'NoNo' in nminus1s list
+    nminus1s.append('NoNo')
 
-lumiBCD=2800.
+    to_use = {
+        'NoPt':[mc_samples],
+        'NoDB':[mc_samples],
+        'NoIso':[mc_samples],
+        'NoTkLayers':[mc_samples],
+        'NoPxHits':[mc_samples],
+        'NoMuHits':[mc_samples],
+        'NoMuMatch':[mc_samples],
+        'NoVtxProb':[mc_samples],
+        'NoB2B':[mc_samples],
+        'NoDptPt':[mc_samples],
+        'NoTrgMtch':[mc_samples],
+        'NoNo':[mc_samples],
+    }
 
-from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
-#raw_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,wjets,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200]
-raw_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200]
-use_samples = [qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets,tWtop,tWantitop,ww_incl,zz_incl,wz,ttbar_pow,dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000]
+    mass_range = [60,80,100,120]
+    maxX = 5000
+    bin_width = 50
+    nBins = maxX/bin_width
+    for i in xrange(3,nBins):
+        ibin = i*bin_width
+        mass_range.append(ibin)
+    nmc = len(mc_samples)
+    nnm1 = len(nminus1s)
+    nbins = len(mass_range)-1
+    sdata = (nnm1,nbins,nmc)
+    stotals = (nnm1,nbins)
+    data = np.zeros(sdata)
+    totals = np.zeros(stotals)
 
-#mc_samples = [nm1entry(sample,False,lumiBCD) for sample in use_samples]
-mc_samples = [nm1entry(sample,False,lumiBCD) for sample in reversed(raw_samples)]
-for mc_sample in mc_samples:
-    exec '%s = mc_sample' % mc_sample.name
+    #
+    # There may be a way to do this in one pass through the input histos, stick to two for now
+    # 
 
-to_use = {
-    'NoPt':[mc_samples],
-    'NoDB':[mc_samples],
-    'NoIso':[mc_samples],
-    'NoTkLayers':[mc_samples],
-    'NoPxHits':[mc_samples],
-    'NoMuHits':[mc_samples],
-    'NoMuMatch':[mc_samples],
-    'NoVtxProb':[mc_samples],
-    'NoB2B':[mc_samples],
-    'NoDptPt':[mc_samples],
-    'NoTrgMtch':[mc_samples],
-    'NoNo':[mc_samples],
-}
-styles = {
-#    'sample':    (color, draw/fill style),
-    #'dataB':      (ROOT.kBlack,     -1),
-    #'dataCD':      (ROOT.kBlack,     -1),
-    #'dataBCD':      (ROOT.kBlack,     -1),
-    #'dy50to120':(ROOT.kGreen, 1001),
-    #'dy120to200':(ROOT.kGreen-4, 1001),
-    #'dy200to400':(ROOT.kGreen+1, 1001),
-    #'dy400to800':(ROOT.kGreen-7, 1001),
-    #'dy800to1400':(ROOT.kGreen-3, 1001),
-    #'dy1400to2300':(ROOT.kGreen+2, 1001),
-    #'dy2300to3500':(ROOT.kGreen-9, 1001),
-    #'dy3500to4500':(ROOT.kGreen-6, 1001),
-    #'dy4500to6000':(ROOT.kGreen-2, 1001),
-    'dy50to120':(ROOT.kGreen+2, 1001),
-    'dy120to200':(ROOT.kGreen+2, 1001),
-    'dy200to400':(ROOT.kGreen+2, 1001),
-    'dy400to800':(ROOT.kGreen+2, 1001),
-    'dy800to1400':(ROOT.kGreen+2, 1001),
-    'dy1400to2300':(ROOT.kGreen+2, 1001),
-    'dy2300to3500':(ROOT.kGreen+2, 1001),
-    'dy3500to4500':(ROOT.kGreen+2, 1001),
-    'dy4500to6000':(ROOT.kGreen+2, 1001),
-    'dy6000_s':(ROOT.kGreen+2, 1001),
-    'ttbar_pow':(ROOT.kBlue,1001),
-    'ww_incl':(ROOT.kOrange,1001),
-    'zz_incl':(ROOT.kOrange,1001),
-    'wz':(ROOT.kOrange,1001),
-    'tWtop':(ROOT.kYellow,1001),
-    'tWantitop':(ROOT.kYellow,1001),
-    'wjets':(ROOT.kViolet,1001),
-    'qcd50to80':(ROOT.kViolet,1001),
-    'qcd80to120':(ROOT.kViolet,1001),
-    'qcd120to170':(ROOT.kViolet,1001),
-    'qcd170to300':(ROOT.kViolet,1001),
-    'qcd300to470':(ROOT.kViolet,1001),
-    'qcd470to600':(ROOT.kViolet,1001),
-    'qcd600to800':(ROOT.kViolet,1001),
-    'qcd800to1000':(ROOT.kViolet,1001),
-    'qcd1000to1400':(ROOT.kViolet,1001),
-    'qcd1400to1800':(ROOT.kViolet,1001),
-    'qcd1800to2400':(ROOT.kViolet,1001),
-    'qcd2400to3200':(ROOT.kViolet,1001),
-    'qcd3200':(ROOT.kViolet,1001),
-}
-
-mass_range = [60,80,100,120]
-maxX = 5000
-bin_width = 50
-nBins = maxX/bin_width
-for i in xrange(3,nBins):
-    ibin = i*bin_width
-    mass_range.append(ibin)
-nmc = len(mc_samples)
-nnm1 = len(nminus1s)
-nbins = len(mass_range)-1
-sdata = (nnm1,nbins,nmc)
-stotals = (nnm1,nbins)
-data = np.zeros(sdata)
-totals = np.zeros(stotals)
-# - Make data
-#   - data matrix 
-#     3 dimensions (nminus1,mass_bin_lowEdge,mc_sample)
-#   - totals matrix
-#     2 dimensions (nminus1,mass_bin_lowEdge)
-for nm1,nminus1 in enumerate(nminus1s):
-    pretty_name = pretty[nminus1]
-    print(nminus1,pretty_name)
-    for entry in to_use[nminus1]: # single item (mc_samples)
-        for ibin in range(len(mass_range)):
-            if ibin == nbins: continue
-            mlow = mass_range[ibin]
-            mhigh = mass_range[ibin+1]
-            total = 0
-            for imc,mc in enumerate(entry):
-                hmc = mc.histos[nminus1]
-                count = get_integral(hmc,mlow,mhigh,integral_only=True,include_last_bin=False)
-                count = count*sample.partial_weight
-                data.itemset((nm1,ibin,imc),count)
-                total = total+count
-            totals.itemset((nm1,ibin),total)
-
-# Make the Histograms
-for nm1,nminus1 in enumerate(nminus1s):
-    pretty_name = pretty[nminus1]
-    lg = ROOT.TLegend(0.65,0.65,0.95,0.85)
-    stack = ROOT.THStack('hs','')
-    for entry in to_use[nminus1]:
-        for mc,sample in enumerate(entry):
-            mc_hist = ROOT.TH1F('mcHist','',nbins,array('f',mass_range))
-            mc_hist.SetMaximum(1.)
+    # - Make data
+    #   - data matrix 
+    #     3 dimensions (nminus1,mass_bin_lowEdge,mc_sample)
+    #   - totals matrix
+    #     2 dimensions (nminus1,mass_bin_lowEdge)
+    for nm1,nminus1 in enumerate(nminus1s):
+        for entry in to_use[nminus1]: # single item (mc_samples)
             for ibin in range(len(mass_range)):
                 if ibin == nbins: continue
-                binContent = data[nm1,ibin,mc]/totals[nm1,ibin]
-                mc_hist.SetBinContent(ibin,binContent)
-            color,fill = styles[sample.name]
-            mc_hist.SetLineColor(color)
-            mc_hist.SetFillColor(color)
-            stack.Add(mc_hist)
-            if sample.name == 'dy50to120':
-                lg.AddEntry(mc_hist,"Drell-Yan",'F' )
-            elif sample.name == 'ttbar_pow':
-                lg.AddEntry(mc_hist,"t#bar{t}","F")
-            elif sample.name == 'ww_incl':
-                lg.AddEntry(mc_hist,"DiBoson","F")
-            elif sample.name == 'qcd80to120':
-                lg.AddEntry(mc_hist,"QCD & W+jets","F")
-            elif sample.name == 'tWtop':
-                lg.AddEntry(mc_hist,"Single Top","F")
-    stack.SetMaximum(1.)
-    stack.SetMinimum(1.E-4)
-    stack.Draw('hist')
-    stack.SetTitle(pretty_name+' Background Percentage')
-    stack.GetXaxis().SetTitle('m(#mu^{+}#mu^{-}) [GeV]')
-    stack.GetYaxis().SetTitle('percentage/%i GeV'%bin_width)
-    stack.GetYaxis().SetTitleOffset(1.4)
-    lg.Draw()
-    ps.save(nminus1+'_bckg_pct',pdf=True,log=True)
+                mlow = mass_range[ibin]
+                mhigh = mass_range[ibin+1]
+                total = 0
+                for imc,mc in enumerate(entry):
+                    hmc = mc.histos[nminus1]
+                    count = get_integral(hmc,mlow,mhigh,integral_only=True,include_last_bin=False, nm1=True)
+                    count = count*sample.partial_weight
+                    data.itemset((nm1,ibin,imc),count)
+                    total = total+count
+                totals.itemset((nm1,ibin),total)
+
+    # Make the Histograms
+    for nm1,nminus1 in enumerate(nminus1s):
+        pretty_name = pretty[nminus1]
+        lg = ROOT.TLegend(0.65,0.65,0.95,0.85)
+        stack = ROOT.THStack('hs','')
+        for entry in to_use[nminus1]:
+            for mc,sample in enumerate(entry):
+                mc_hist = ROOT.TH1F('mcHist','',nbins,array('f',mass_range))
+                mc_hist.SetMaximum(1.)
+                for ibin in range(len(mass_range)):
+                    if ibin == nbins: continue
+                    binContent = data[nm1,ibin,mc]/totals[nm1,ibin]
+                    mc_hist.SetBinContent(ibin,binContent)
+                color,fill = styles[sample.name]
+                mc_hist.SetLineColor(color)
+                mc_hist.SetFillColor(color)
+                stack.Add(mc_hist)
+                if sample.name == 'dy50to120':
+                    lg.AddEntry(mc_hist,"Drell-Yan",'F' )
+                elif sample.name == 'ttbar_pow':
+                    lg.AddEntry(mc_hist,"t#bar{t}","F")
+                elif sample.name == 'ww_incl':
+                    lg.AddEntry(mc_hist,"DiBoson","F")
+                elif sample.name == 'qcd80to120':
+                    lg.AddEntry(mc_hist,"QCD & W+jets","F")
+                elif sample.name == 'tWtop':
+                    lg.AddEntry(mc_hist,"Single Top","F")
+        stack.SetMaximum(1.)
+        stack.SetMinimum(1.E-4)
+        stack.Draw('hist')
+        stack.SetTitle(pretty_name+' Background Percentage')
+        stack.GetXaxis().SetTitle('m(#mu^{+}#mu^{-}) [GeV]')
+        stack.GetYaxis().SetTitle('percentage/%i GeV'%bin_width)
+        stack.GetYaxis().SetTitleOffset(1.4)
+        lg.Draw()
+        name = nminus1+'_bckg_pct'
+        print(nminus1,pretty_name,name)
+        ps.save(name,pdf=True,log=True)
+
+# ************************************************************************
+# Main
+# ************************************************************************
+if __name__=='__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='submits limits for a given mass')
+    parser.add_argument('--tag',help='Tagged directory name for input histograms and output plots',default='')
+    parser.add_argument('--stats',help='Print stats',default=False)
+    parser.add_argument('--lumi',help='Integrated luminosity in pb-1',default='1000')
+    args = parser.parse_args()
+
+    tag = args.tag
+    if not os.path.exists('plots/%s'%tag):
+        raise ValueError('Tagged directory %s does not exist!'%tag)
+
+    draw_bckg_pct_test(tag, args.stats, float(args.lumi))
+

--- a/test/NMinus1Effs/draw_mass.py
+++ b/test/NMinus1Effs/draw_mass.py
@@ -2,620 +2,234 @@
 
 # (py draw.py >! plots/nminus1effs/out.draw) && tlp plots/nminus1effs
 
-from pprint import pprint
-import sys, os
-from array import array
-from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
-set_zp2mu_style()
-ROOT.gStyle.SetPadTopMargin(0.02)
-ROOT.gStyle.SetPadRightMargin(0.02)
-ROOT.gStyle.SetTitleX(0.12)
-#ROOT.gStyle.SetTitleH(0.07)
-ROOT.TH1.AddDirectory(0)
+# Import nm1entry.py
+# - from MCSamples and roottools import *
+# - nm1entry class
+# - nminus1s list
+# - pretty dictionary
+# - styles dictionary
+from nm1entry import *
 
-outfile = ROOT.TFile("whargl.root","recreate")
-iarp=0
-mcN=0
-drawDY = True
-do_tight = 'tight' in sys.argv
-#psn = 'plots/nminus1effs'
-psn = 'plots/paper2016'
-# 'plots' = '/afs/cern.ch/work/c/cschnaib/NMinus1Effs/plots/TAG/'
-if do_tight:
-    psn += '_tight'
-ps = plot_saver(psn, size=(600,600), log=False, pdf=True)
-ps.c.SetBottomMargin(0.2)
+def draw_mass_test(tag, printStats, lumi, do_tight=False):
 
+    # Specific stylings for this script on top of zp2mu_style
+    ROOT.gStyle.SetPadTopMargin(0.02)
+    ROOT.gStyle.SetPadRightMargin(0.02)
+    ROOT.gStyle.SetTitleX(0.12)
+    #ROOT.gStyle.SetTitleH(0.07)
+    ROOT.TH1.AddDirectory(0)
+    outfile = ROOT.TFile("whargl.root","recreate")
+    iarp=0
 
-if do_tight:
-    nminus1s = [
-        #'TiPt',
-        'TiDB',
-        'TiGlbChi2',
-        'TiIso',
-        'TiTkLayers',
-        'TiPxHits',
-        'TiMuHits',
-        'TiMuMatch',
-        ]
-else:
-    nminus1s = [
-        'NoPt',
-        'NoDB',
-        'NoIso',
-        'NoTkLayers',
-        'NoPxHits',
-        'NoMuHits',
-        'NoMuMatch',
-        'NoVtxProb',
-        'NoB2B',
-        'NoDptPt',
-                #'NoCosm',
-        'NoTrgMtch',
-        ]
+    # 'plots' = '/afs/cern.ch/work/c/cschnaib/Zprime2muAnalysis/NMinus1Effs/plots/TAG/tag'
+    # TAG = MC/Data production TAG
+    # tag = sub tag for each version of plots made with a single production TAG
+    psn = 'plots'
+    if tag:
+        psn = 'plots/%s'%tag
 
-pretty = {
-    'NoPt': 'p_{T} > 53 GeV',
-    'NoTkLayers': '# tk lay > 5',
-    'NoPxHits': '# px hits > 0',
-    'NoMuStns': '# mu segs > 1',
-    'NoDB': '|dxy| < 0.2',
-    'NoGlbChi2': 'glb #chi^{2}/ndf < 10',
-    'NoTkMuon': 'isTrackerMuon',
-    'NoMuHits': '# mu hits > 0',
-    'NoMuMatch': '# matched stations > 1',
-    'NoCosm': 'anti-cosmic',
-    'NoTrgMtch': 'HLT match',
-    'NoB2B': 'back-to-back',
-    'NoVtxProb': '#chi^{2} #mu#mu vtx < 20',
-    'NoDptPt': 'dpT/pT',
-    'NoIso': 'rel. tk. iso.',
-    #'data': 'Data, %.1f fb^{-1}',
-    'data': 'Data, %.1f fb^{-1}, MuonOnly',
-    'dataB': 'Data RunB, %.1f fb^{-1}, MuonOnly',
-    'dataCD': 'Data RunC+D, %.1f fb^{-1}, MuonOnly',
-    'dataBCD': 'Data RunB+C+D, %.1f fb^{-1}, MuonOnly',
-    'mcsum_lumi': 'Simulation',
-    'mcsum_ref': 'Simulation',
-    'mc50m120_lumi': 'Simulation 60 < M < 120 GeV',
-    'mc50m120_ref': 'Simulation 60 < M < 120 GeV',
-    'mc120m_lumi': 'Simulation M > 120 GeV',
-    'mc120m_ref': 'Simulation M > 120 GeV',
-    'mc800m2300_lumi': 'Simulation 800 < M < 2300 GeV',
-    'mc800m2300_ref': 'Simulation 800 < M < 2300 GeV',
-    'mc400m2300_lumi': 'Simulation 400 < M < 2300 GeV',
-    'mc400m2300_ref': 'Simulation 400 < M < 2300 GeV',
-    'zmumu': 'Z#rightarrow#mu#mu, 60 < M < 120 GeV',
-    'dy120_c1': 'DY#rightarrow#mu#mu, M > 120 GeV',
-    'dy200_c1': 'DY#rightarrow#mu#mu, M > 200 GeV',
-    'dy500_c1': 'DY#rightarrow#mu#mu, M > 500 GeV',
-    'dy1000_c1': 'DY#rightarrow#mu#mu, M > 1000 GeV',
-    'dy50': 'DY#rightarrow#mu#mu madgraph',
-#    'dy50': 'DY#rightarrow#mu#mu, M > 50 GeV',
-    'dy50to120': 'DY#rightarrow#mu#mu powheg',
-    'dy50_startup': 'DY#rightarrow#mu#mu startup',
-    'ttbar': 't#bar{t}',
-    'ttbar_pow': 't#bar{t} powheg',
-    'ttbar_startup': 't#bar{t} startup',
-    'ww_incl': 'WW',
-    'zz_incl': 'ZZ',
-    'wz' : 'WZ',
-    'inclmu15': 'QCD',
-    'zssm1000': 'Z\' SSM, M=1000 GeV',
-    'zpsi5000': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_m1TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_1m3TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_3mTeV': 'Z\'_{#psi}, M=5000 GeV',
-    '60m120_BCD': '60 < m < 120 GeV',
-    '60m120_CD': '60 < m < 120 GeV',
-    '60m120': '60 < m < 120 GeV',
-    '70m110': '70 < m < 110 GeV',
-    '120m200': '120 < m < 200 GeV', 
-    '200m400': '200 < m < 400 GeV',
-    '400m600': '400 < m < 600 GeV',
-    '200m': 'm > 200 GeV',
-    '50m': 'm > 50 GeV',
-    '70m': 'm > 70 GeV',
-    '120m_BCD': 'm > 120 GeV',
-    '120m_CD': 'm > 120 GeV',
-    '120m': 'm > 120 GeV',
-    'DY120to200Powheg': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
-    'DY200to400Powheg': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
-    'DY400to800Powheg': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
-    'DY800to1400Powheg': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
-    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
-    '400m800' : '400 < m < 800 GeV',
-    '800m1400': '800 < m < 1400 GeV',
-    '1400m2300':'1400 < m < 2300 GeV',
-    '800m2300':'800 < m < 2300 GeV',
-    '400m2300':'400 < m < 2300 GeV',
-    'all_lumi':'Simulation M > 120 GeV',
-    'all_ref':'Simulation M > 120 GeV',
-    '120m1400':'120 < M < 1400 GeV',
-    }
+    # cjsbad - fix the referencing to tightnm1...
+    #if do_tight:
+    #    psn += '_tight'
+    #    nminus1s = tightnm1[:]
 
-class nm1entry:
-    def __init__(self, sample, is_data, lumi):
-        if type(sample) == str:
-            self.name = sample
-            self.fn = 'data/ana_nminus1_%s.root'%sample
-            #self.fn = self.make_fn(sample) if is_data else None
-            self.lumi = lumi if is_data else None
-            self.is_data = is_data
-        else:
-            self.name = sample.name
-            self.fn = self.make_fn(self.name)
-            self.partial_weight = sample.partial_weight
-            self.is_data = is_data
-        self.prepare_histos()
-            
-    def make_fn(self, name):
-        return 'mc/ana_nminus1_%s.root' % name
-    
-    def prepare_histos(self):
-        self.histos = {}
-        if self.fn is not None:
-            f = ROOT.TFile(self.fn)
-            for nminus1 in nminus1s + ['NoNo']:
-                self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()#DileptonMass
-                '''
-                if nminus1=='NoVtxProb':
-                    self.histos[nminus1] = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()#DileptonMass
-                '''
+    ps = plot_saver(psn, size=(600,600), log=False, pdf=True)
+    ps.c.SetBottomMargin(0.2)
 
-    def prepare_histos_sum(self, samples, lumi):
-        self.histos = {}
-        for nminus1 in nminus1s + ['NoNo']:
-            hs = []
-            #print '%20s%20s%21s%20s%20s' % ('cut', 'sampe name', 'partial weight', 'scale(ref)','scale(lumi)')
-            for sample in samples:
-                f = ROOT.TFile(self.make_fn(sample.name))
-                if nminus1 == 'NoVtxProb':
-                    h = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
-                #print '%20s%20s%20.15f%20f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS, lumiBCD)
-                # partial_weight = cross_section * k_factor / Nevents
-                if lumi>0:
-                    # scale to luminosity for comparision of single dataset to MC
-                    h.Scale(sample.partial_weight * lumi) 
-                    #print nminus1, sample.name, sample.partial_weight*lumi
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, lumi)
-                if lumi<0:
-                    # scale to reference cross section/Nevents for comparision of multiple datasets to MC
-                    h.Scale(sample.partial_weight * refN / refXS)  
-                    #print nminus1, sample.name, sample.partial_weight*refN/refXS
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS)
-                hs.append(h)
-            hsum = hs[0].Clone()
-            for h in hs[1:]:
-                hsum.Add(h)
-            self.histos[nminus1] = hsum
+    data = nm1entry('data', True, lumi)#lumiCD )
 
-#data, lumi = nm1entry('data', True), 242.8 # lumi in pb
-nolumi = -1
-lumiB = 50.7 
-lumiCD = 2619.44
-lumiD = 2572.19
-#lumiBCD = 2660.14
-lumiBCD = 2800.
-#dataB = nm1entry('dataB', True, lumiB)#lumiB )
-#dataCD = nm1entry('dataCD', True, lumiCD)#lumiCD )
-dataBCD = nm1entry('dataBCD', True, lumiBCD)#lumiCD )
-#dataD = nm1entry('dataD', True, lumiD )
-#mcsum_lumi = nm1entry('mcsum_lumi',False,lumiBCD)
-#mcsum_ref = nm1entry('mcsum_ref',False,nolumi)
-#DYmc = nm1entry('DYmc',False,lumiBCD)
-#nonDYmc = nm1entry('nonDYmc',False,lumiBCD)
-#wjets = nm1entry('wjets',False,lumiBCD)
+    refXS = dy50to120.cross_section
+    refN = dy50to120.nevents
 
-from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
-#raw_samples = [dy50to120,DY120to200Powheg,DY200to400Powheg,DY400to800Powheg,DY800to1400Powheg,dy1400to2300,dy2300to3500,DY3500to4500Powheg,dy4500to6000,ttbar_pow_s,ww_incl_s,zz_incl,wz,tWtop,tWantitop,wjets]#inclmu15,
-#,qcd600to800,qcd120to170
-#raw_samples = [dy50to120_s,dy120to200_s,dy200to400_s,dy400to800_s,dy800to1400_s,dy1400to2300_s,dy2300to3500_s,dy3500to4500_s,dy4500to6000_s,dy6000_s,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,inclmu15,zpsi5000,qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]
+    samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
+    # All MC samples
+    # lumi
+    mc_samples = [nm1entry(sample,False,lumi) for sample in samples]
+    #for mc_sample in mc_samples:
+    #    exec '%s = mc_sample' % mc_sample.name
 
-raw_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,zpsi5000,wjets]#dy6000_s,
-use_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]#dy6000_s,
+    #bin_width = 20
+    #maxX = 2500
+    #minX = 60
+    #nBins = (maxX-minX)/bin_width
+    #mass_range = []
+    #for i in range(3,nBins):
+    #    ibin = i*bin_width
+    #    mass_range.append(ibin)
+    #print mass_range
+    mass_range = [60,120,180,240,320,500,1000,2500]
 
-#dy_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000]#dy6000,
+    to_use = {
+    #   'sample':[MC,Data],
+        'NoPt':[mc_samples,data],
+        'NoDB':[mc_samples,data],
+        'NoIso':[mc_samples,data],
+        'NoTkLayers':[mc_samples,data],
+        'NoPxHits':[mc_samples,data],
+        'NoMuHits':[mc_samples,data],
+        'NoMuMatch':[mc_samples,data],
+        'NoVtxProb':[mc_samples,data],
+        'NoB2B':[mc_samples,data],
+        'NoDptPt':[mc_samples,data],
+        'NoTrgMtch':[mc_samples,data],
+        }
 
-#nonDY_samples = [ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop,qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]#dy6000_s,
-
-#EWKnoDY_samples = [ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop]#dy6000_s,
-
-#noQCD_samples = [dy50to120_s,dy120to200_s,dy200to400_s,dy400to800_s,dy800to1400_s,dy1400to2300_s,dy2300to3500_s,dy3500to4500_s,dy4500to6000_s,ttbar_pow,ww_incl,zz_incl,wz,wjets,tWtop,tWantitop]
-
-#QCD_samples = [qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200]
-
-#diboson_samples = [ww_incl, zz_incl, wz]
-
-#stop_samples = [tWtop, tWantitop]
-
-#ttbar_samples = [ttbar_pow]
-
-#wjets_samples = [wjets]
-
-#noQCDwjets_samples = [dy50to120_s,dy120to200_s,dy200to400_s,dy400to800_s,dy800to1400_s,dy1400to2300_s,dy2300to3500_s,dy3500to4500_s,dy4500to6000_s,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop]
-
-#QCDwjets_samples = [qcd50to80,qcd80to120,qcd170to300,qcd300to470,qcd470to600,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd3200,wjets]
-
-#zpsi5000_samples = [zpsi5000]
-
-#EWKnoDYwjets_samples = [ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop]
-
-#refXS = dy50to120_s.cross_section
-#refN = dy50to120_s.nevents
-
-# All MC samples
-# lumi
-#mcsum_lumi.prepare_histos_sum(use_samples,lumiBCD)
-mc_samples = [nm1entry(sample,False,lumiBCD) for sample in use_samples]
-for mc_sample in mc_samples:
-    exec '%s = mc_sample' % mc_sample.name
-
-#dy = [nm1entry(sample,False,lumiBCD) for sample in dy_samples]
-#for dy_sample in dy_samples:
-#    exec '%s = dy_sample' % dy_sample.name
-#noDY = [nm1entry(sample,False,lumiBCD) for sample in nonDY_samples]
-#for nonDY_sample in nonDY_samples:
-#    exec '%s = nonDY_sample' % nonDY_sample.name
-#qcd = [nm1entry(sample,False,lumiBCD) for sample in QCD_samples]
-#for QCD_sample in QCD_samples:
-#    exec '%s = QCD_sample' % QCD_sample.name
-#diboson = [nm1entry(sample,False,lumiBCD) for sample in diboson_samples]
-#stop = [nm1entry(sample,False,lumiBCD) for sample in stop_samples]
-#ttbar = [nm1entry(sample,False,lumiBCD) for sample in ttbar_samples]
-#noQCD = [nm1entry(sample,False,lumiBCD) for sample in noQCD_samples]
-#wjets = [nm1entry(sample,False,lumiBCD) for sample in wjets_samples]
-#noQCDwjets = [nm1entry(sample,False,lumiBCD) for sample in noQCDwjets_samples]
-#EWKnoDY = [nm1entry(sample,False,lumiBCD) for sample in EWKnoDY_samples]
-#QCDwjets = [nm1entry(sample,False,lumiBCD) for sample in QCDwjets_samples]
-#Zpsi5000 = [nm1entry(sample,False,lumiBCD) for sample in zpsi5000_samples]
-#EWKnoDYwjets = [nm1entry(sample,False,lumiBCD) for sample in EWKnoDYwjets_samples]
-#
-
-# ref
-#mcsum_ref.prepare_histos_sum(use_samples, nolumi) 
-#mc_samples_ref = [nm1entry(sample,False,nolumi) for sample in use_samples]
-#for mc_sample in mc_samples_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-
-#DYmc.prepare_histos_sum(DYmc_list,lumiBCD)
-#nonDYmc.prepare_histos_sum(nonDYmc_list,lumiBCD)
-
-#bin_width = 20
-#maxX = 2500
-#minX = 60
-#nBins = (maxX-minX)/bin_width
-#mass_range = []
-#for i in range(3,nBins):
-#    ibin = i*bin_width
-#    mass_range.append(ibin)
-#print mass_range
-mass_range = [60,120,180,240,320,500,1000,2500]
-
-to_use = {
-#   'sample':[MC,Data],
-    #'NoPt':[DYmc,nonDYmc,dataCD],
-    #'NoDB':[DYmc,nonDYmc,dataCD],
-    #'NoIso':[DYmc,nonDYmc,dataCD],
-    #'NoTkLayers':[DYmc,nonDYmc,dataCD],
-    #'NoPxHits':[DYmc,nonDYmc,dataCD],
-    #'NoMuHits':[DYmc,nonDYmc,dataCD],
-    #'NoMuMatch':[DYmc,nonDYmc,dataCD],
-    #'NoVtxProb':[DYmc,nonDYmc,dataCD],
-    #'NoB2B':[DYmc,nonDYmc,dataCD],
-    #'NoDptPt':[DYmc,nonDYmc,dataCD],
-    #'NoTrgMtch':[DYmc,nonDYmc,dataCD],
-
-    'NoPt':[mc_samples,dataBCD],
-    'NoDB':[mc_samples,dataBCD],
-    'NoIso':[mc_samples,dataBCD],
-    'NoTkLayers':[mc_samples,dataBCD],
-    'NoPxHits':[mc_samples,dataBCD],
-    'NoMuHits':[mc_samples,dataBCD],
-    'NoMuMatch':[mc_samples,dataBCD],
-    'NoVtxProb':[mc_samples,dataBCD],
-    'NoB2B':[mc_samples,dataBCD],
-    'NoDptPt':[mc_samples,dataBCD],
-    'NoTrgMtch':[mc_samples,dataBCD],
-
-    #'NoPt':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoDB':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoIso':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoTkLayers':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoPxHits':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoMuHits':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoMuMatch':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoVtxProb':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoB2B':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoDptPt':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    #'NoTrgMtch':[EWKnoDY,Zpsi5000,noDY,dy,dataBCD],
-    }
-
-styles = {
-#    'sample':    (color, draw/fill style),
-#    'data':      (ROOT.kBlack,     -1),
-    'dataB':      (ROOT.kBlack,     -1),
-    'dataCD':      (ROOT.kBlack,     -1),
-    'dataBCD':      (ROOT.kBlack,     -1),
-#    'zmumu':     (ROOT.kRed,     3001),
-#    'dy50':      (ROOT.kBlue,     1001),
-#    'dy50_startup':      (ROOT.kViolet+2,     3001),
-#    'dy200_c1':  (ROOT.kRed,     1001),
-#    'dy500_c1':  (ROOT.kRed,     1001),
-#    'dy1000_c1': (ROOT.kBlue,    1001),
-#    'ttbar':     (ROOT.kGreen+2, 3005),
-#    'ttbar_startup':     (ROOT.kGreen+2, 3005),
-#    'ww_incl':    (ROOT.kBlue,    3004),
-#    'zz_incl':    (62,            3006),
-#    'wz' :       (64,            3007),
-#    'inclmu15':  (28,            3002),
-    'mc50m120_lumi':     (ROOT.kGreen+2, 1001),
-    'mc50m120_ref':     (ROOT.kGreen+2, 1001),
-    'mc120m_lumi':     (ROOT.kGreen+2, 1001),
-    'mc120m_ref':     (ROOT.kGreen+2, 1001),
-    'mc800m2300_lumi':     (ROOT.kGreen+2, 1001),
-    'mc800m2300_ref':     (ROOT.kGreen+2, 1001),
-    'mc400m2300_lumi':     (ROOT.kGreen+2, 1001),
-    'mc400m2300_ref':     (ROOT.kGreen+2, 1001),
-    'dy50to120':      (ROOT.kGreen+2,     1001),
-    'DY120to200Powheg':  (ROOT.kGreen+2, 1001),
-    'DY200to400Powheg':  (ROOT.kGreen+2, 1001),
-    'DY400to800Powheg':  (ROOT.kGreen+2, 1001),
-    'DY800to1400Powheg': (ROOT.kGreen+2, 1001),
-    'dy1400to2300':      (ROOT.kGreen+2, 1001),
-    'ttbar_pow':     (ROOT.kGreen+2, 1001),
-    'mcsum_lumi':    (ROOT.kGreen+2, 1001),
-    'mcsum_ref':    (ROOT.kGreen+2, 1001),
-    'zpsi5000':    (ROOT.kBlue, 1001),
-    'zpsi5000_m1TeV':    (ROOT.kBlue, 1001),
-    'zpsi5000_1m3TeV':    (ROOT.kBlue, 1001),
-    'zpsi5000_3mTeV':    (ROOT.kBlue, 1001),
-    'DYmc': (ROOT.kGreen, 3001),
-    'nonDYmc': (ROOT.kRed, 1001),
-    'dy':(ROOT.kGreen,1001),
-    }
-
-yrange = {
-#   'sample':    (ymin,ymax),
-    'NoPt':      (0.00,1.01),
-    'NoDB':      (0.95,1.001),
-    'NoIso':     (0.60,1.01),
-    'NoTkLayers':(0.95,1.001),
-    'NoPxHits':  (0.80,1.001),
-    'NoMuHits':  (0.80,1.001),
-    'NoMuMatch': (0.80,1.005),
-    'NoVtxProb': (0.90,1.001),
-    'NoB2B':     (0.80,1.001),
-    'NoDptPt':   (0.95,1.001),
-    'NoTrgMtch': (0.90,1.001),
-    }
-#global_ymin = 0.
-global_ymin = None
-
-def table_wald(entry,nminus1, mass_range):
-    print entry.name, nminus1
-    hnum = entry.histos['NoNo']
-    hden = entry.histos[nminus1]
-    #print '%20s%27s%23s%20s%16s%25s%26s' % ('cut', 'mass range','numerator', 'denominator', 'efficiency', '- 68% CL-CP +','68% CL-Wald')
-    for mbin in range(len(mass_range)):
-        if mbin == (len(mass_range)-1): break
-        mlow = mass_range[mbin]
-        mhigh = mass_range[mbin+1] 
-        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-        pcp,lcp,hcp = clopper_pearson(num, den)
-        if num==0 and den==0:
-            eff = 0
-            errw = 0
-        else:
-            eff = num/den
-            if (eff*(1-eff))<0:
-                print "what is this"
-                print 'NM1, sample, mlow, mhigh, num, den'
-                print nminus1, entry.name, mlow, mhigh, num, den
-                eff = 1
-                errw = 0
-            else:
-                errw = (eff*(1-eff)/den)**0.5
-        if 'data' not in entry.name:
-            num = num*entry.partial_weight*lumiBCD
-            den = den*entry.partial_weight*lumiBCD
-        #print '%20s%15i%15i%20f%20f%15f%15f%15f%23f'     % (nminus1, mlow, mhigh, num, den, eff, eff-lcp, hcp-eff,        errw)
-        #print '%20s%15i%15i%20f%20f%15f%15f%15f%15f%16f' % (nminus1, mlow, mhigh, num, den, eff, lcp,     hcp,     eff-errw, eff+errw)
-        print ' '
-    print '---------------------------------------------'
-
-def table(entry,nminus1, mass_range):
-    print entry.name
-    hnum = entry.histos['NoNo']
-    hden = entry.histos[nminus1]
-    print '%20s%27s%23s%20s%20s%22s' % ('cut', 'mass range', 'numerator', 'denominator', 'efficiency', '68% CL')
-    for mbin in range(len(mass_range)):
-        if mbin == (len(mass_range)-1): break
-        mlow = mass_range[mbin]
-        mhigh = mass_range[mbin+1] 
-        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-        e,l,h = clopper_pearson(num, den)
-        print '%20s%15i%15i%20f%20f%20f%15f%15f' % (nminus1, mlow, mhigh, num, den, p_hat, p_hat_e, p_hat_e)
-
-ROOT.gStyle.SetTitleX(0.25)
-ROOT.gStyle.SetTitleY(0.50)
-
-for nminus1 in nminus1s:
-    pretty_name = pretty[nminus1]
-    print nminus1, pretty_name
-    lg = ROOT.TLegend(0.25, 0.21, 0.91, 0.44)
-    lg.SetTextSize(0.03)
-    lg.SetFillColor(0)
-    lg.SetBorderSize(1)
-    
-    same = 'A'
-    effs = []
+    yrange = {
+    #   'sample':    (ymin,ymax),
+        'NoPt':      (0.00,1.01),
+        'NoDB':      (0.95,1.001),
+        'NoIso':     (0.60,1.01),
+        'NoTkLayers':(0.95,1.001),
+        'NoPxHits':  (0.80,1.001),
+        'NoMuHits':  (0.80,1.001),
+        'NoMuMatch': (0.80,1.005),
+        'NoVtxProb': (0.90,1.001),
+        'NoB2B':     (0.80,1.001),
+        'NoDptPt':   (0.95,1.001),
+        'NoTrgMtch': (0.90,1.001),
+        }
+    #global_ymin = 0.
+    global_ymin = None
 
 
+    ROOT.gStyle.SetTitleX(0.25)
+    ROOT.gStyle.SetTitleY(0.50)
 
-    for entry in to_use[nminus1]: #,mass_range 
-
-        #table(entry,nminus1, mass_range)
-
-        l = len(mass_range)-1
-        nminus1_num = ROOT.TH1F('num', '', l, array('f',mass_range))
-        nminus1_den = ROOT.TH1F('den', '', l, array('f',mass_range))
-
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            #table_wald(entry,nminus1,mass_range)
-            color, fill = styles[entry.name]
-            hnum = entry.histos['NoNo']
-            hden = entry.histos[nminus1]
-            for mbin in range(len(mass_range)):
-                if mbin == (len(mass_range)-1): continue
-                mlow = mass_range[mbin]
-                mhigh = mass_range[mbin+1]
-                num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-                den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-                nminus1_num.SetBinContent(mbin+1, num)
-                nminus1_den.SetBinContent(mbin+1, den)
-            eff,p,epl,eph = binomial_divide(nminus1_num, nminus1_den)
-        else:
-            #for a,mc in enumerate(entry):
-            #    table_wald(mc,nminus1,mass_range)
-            p_hats = []
-            errsW = []
-            x = []
-            ex = []
-            for mbin in range(len(mass_range)):
-                if mbin == (len(mass_range)-1): continue
-                numTot = 0
-                denTot = 0
-                err2sum = 0
-                numsW = []
-                densW = []
-                err2s = []
-                for i,mc in enumerate(entry):
-                    hnum = mc.histos['NoNo']
-                    hden = mc.histos[nminus1]
+    for nminus1 in nminus1s:
+        pretty_name = pretty[nminus1]
+        lg = ROOT.TLegend(0.25, 0.21, 0.91, 0.44)
+        lg.SetTextSize(0.03)
+        lg.SetFillColor(0)
+        lg.SetBorderSize(1)
+        same = 'A'
+        effs = []
+        for entry in to_use[nminus1]: #,mass_range 
+            l = len(mass_range)-1
+            nminus1_num = ROOT.TH1F('num', '', l, array('f',mass_range))
+            nminus1_den = ROOT.TH1F('den', '', l, array('f',mass_range))
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                if printStats: table(entry,nminus1,mass_range)
+                color, fill = styles[entry.name]
+                hnum = entry.histos['NoNo']
+                hden = entry.histos[nminus1]
+                for mbin in range(len(mass_range)):
+                    if mbin == (len(mass_range)-1): continue
                     mlow = mass_range[mbin]
                     mhigh = mass_range[mbin+1]
-                    numInt = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-                    denInt = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-                    if numInt<=denInt and denInt>0:
-                        p_hat_mc = float(numInt)/denInt
-                        err2 = p_hat_mc*(1-p_hat_mc)/denInt
-                    elif numInt>denInt:
-                        print "numInt>denInt"
-                        print "NM1, sample, mlow, mhigh, num, den"
-                        print nminus1, mc.name, mlow, mhigh, numInt, denInt
-                        print
-                        p_hat_mc = 1
-                        err2 = 0
-                    else:
-                        if numInt!=0 or denInt!=0:
-                            print "ELSE"
+                    num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                    den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                    nminus1_num.SetBinContent(mbin+1, num)
+                    nminus1_den.SetBinContent(mbin+1, den)
+                eff,p,epl,eph = binomial_divide(nminus1_num, nminus1_den)
+            else:
+                if printStats: table_wald(mc,nminus1,mass_range)
+                p_hats = []
+                errsW = []
+                x = []
+                ex = []
+                for mbin in range(len(mass_range)):
+                    if mbin == (len(mass_range)-1): continue
+                    numTot = 0
+                    denTot = 0
+                    err2sum = 0
+                    numsW = []
+                    densW = []
+                    err2s = []
+                    for i,mc in enumerate(entry):
+                        hnum = mc.histos['NoNo']
+                        hden = mc.histos[nminus1]
+                        mlow = mass_range[mbin]
+                        mhigh = mass_range[mbin+1]
+                        numInt = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                        denInt = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                        if numInt<=denInt and denInt>0:
+                            p_hat_mc = float(numInt)/denInt
+                            err2 = p_hat_mc*(1-p_hat_mc)/denInt
+                        elif numInt>denInt:
+                            print "numInt>denInt"
                             print "NM1, sample, mlow, mhigh, num, den"
                             print nminus1, mc.name, mlow, mhigh, numInt, denInt
                             print
-                        p_hat_mc = 0
-                        err2 = 0
-                    numTot = numTot + numInt*mc.partial_weight
-                    denTot = denTot + denInt*mc.partial_weight
-                    numsW.append(numInt*mc.partial_weight)
-                    densW.append(denInt*mc.partial_weight)
-                    err2s.append(err2)
-                p_hat = float(numTot)/denTot
-                err2sum = sum( ((m/denTot)**2 * e2) for m,e2 in zip(densW,err2s))
-                if err2sum<0:
-                    err2sum = 0
-                elif p_hat==0:
-                    err2sum = 0
-                p_hats.append(p_hat)
-                errsW.append(err2sum**0.5)
-                x.append(nminus1_num.GetXaxis().GetBinCenter(mbin+1))
-                ex.append(nminus1_num.GetXaxis().GetBinWidth(mbin+1)/2)
-            eff = ROOT.TGraphAsymmErrors(len(x), *[array('d',obj) for obj in (x,p_hats,ex,ex,errsW,errsW)])
-        eff.SetTitle(pretty_name)
-        ymin, ymax = yrange[nminus1]
-        eff.GetYaxis().SetRangeUser(global_ymin if global_ymin is not None else ymin, ymax)
-        eff.GetXaxis().SetTitle('m(#mu#mu) [GeV]')
-        eff.GetYaxis().SetLabelSize(0.027)
-        eff.GetYaxis().SetTitle('n-1 efficiency')
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            draw = 'P'
-            eff.SetLineColor(color)
-            eff.SetMarkerStyle(20)
-            eff.SetMarkerSize(1.05)
-            eff.SetMarkerColor(color)
-            #lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
-            lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
-        else:
-            if len(entry)==9:
-                draw = '2'
-                eff.SetLineColor(ROOT.kGreen+2)
-                eff.SetFillColor(ROOT.kGreen+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'DY MC 76X','LF')
-            elif len(entry)==15:
-                draw = '2'
-                eff.SetLineColor(ROOT.kOrange+2)
-                eff.SetFillColor(ROOT.kOrange+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'EWK MC','LF')
-            elif len(entry)==1:
-                draw = '2'
-                eff.SetLineColor(ROOT.kYellow+1)
-                eff.SetFillColor(ROOT.kYellow+1)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'Z\'_{#psi} (5 TeV)','LF')
-            elif len(entry)==10:
-                draw = '2'
-                eff.SetLineColor(ROOT.kViolet)
-                eff.SetFillColor(ROOT.kViolet)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'QCD MC','LF')
-            elif len(entry)==11:
-                draw = '2'
-                eff.SetLineColor(ROOT.kBlue+2)
-                eff.SetFillColor(ROOT.kBlue+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'QCD + W+jets MC','LF')
-            elif len(entry)==7:
-                draw = '2'
-                eff.SetLineColor(ROOT.kRed+2)
-                eff.SetFillColor(ROOT.kRed+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'EWK no DY MC','LF')
-            elif len(entry)==6:
-                draw = '2'
-                eff.SetLineColor(ROOT.kRed+2)
-                eff.SetFillColor(ROOT.kRed+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'EWK','LF')
-            elif len(entry)==len(use_samples):
-                draw = '2'
-                eff.SetLineColor(ROOT.kGreen+2)
-                eff.SetFillColor(ROOT.kGreen+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'All Simulation','LF')
+                            p_hat_mc = 1
+                            err2 = 0
+                        else:
+                            if numInt!=0 or denInt!=0:
+                                print "ELSE"
+                                print "NM1, sample, mlow, mhigh, num, den"
+                                print nminus1, mc.name, mlow, mhigh, numInt, denInt
+                                print
+                            p_hat_mc = 0
+                            err2 = 0
+                        numTot = numTot + numInt*mc.partial_weight
+                        denTot = denTot + denInt*mc.partial_weight
+                        numsW.append(numInt*mc.partial_weight)
+                        densW.append(denInt*mc.partial_weight)
+                        err2s.append(err2)
+                    p_hat = float(numTot)/denTot
+                    err2sum = sum( ((m/denTot)**2 * e2) for m,e2 in zip(densW,err2s))
+                    if err2sum<0:
+                        err2sum = 0
+                    elif p_hat==0:
+                        err2sum = 0
+                    p_hats.append(p_hat)
+                    errsW.append(err2sum**0.5)
+                    x.append(nminus1_num.GetXaxis().GetBinCenter(mbin+1))
+                    ex.append(nminus1_num.GetXaxis().GetBinWidth(mbin+1)/2)
+                eff = ROOT.TGraphAsymmErrors(len(x), *[array('d',obj) for obj in (x,p_hats,ex,ex,errsW,errsW)])
+            eff.SetTitle(pretty_name)
+            ymin, ymax = yrange[nminus1]
+            eff.GetYaxis().SetRangeUser(global_ymin if global_ymin is not None else ymin, ymax)
+            eff.GetXaxis().SetTitle('m(#mu#mu) [GeV]')
+            eff.GetYaxis().SetLabelSize(0.027)
+            eff.GetYaxis().SetTitle('n-1 efficiency')
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                draw = 'P'
+                eff.SetLineColor(color)
+                eff.SetMarkerStyle(20)
+                eff.SetMarkerSize(1.05)
+                eff.SetMarkerColor(color)
+                #lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
+                lg.AddEntry(eff, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
             else:
-                draw = '2'
-                eff.SetLineColor(ROOT.kBlue+2)
-                eff.SetFillColor(ROOT.kBlue+2)
-                eff.SetFillStyle(1001)
-                lg.AddEntry(eff,'EWK+QCD MC','LF')
-        #lg.AddEntry(eff, pretty.get(entry.name, entry.name), 'LF')
-        draw += same
-        eff.Draw(draw)
-        effs.append(eff)
-        same = ' same'
-        outfile.cd()
-        eff.Write("arp%d"%iarp)
-        iarp+=1
-    # end for entry in to_use[name]: # entry is a specific sample
-    lg.Draw()
-    ps.save(nminus1+'_mass')
-    print
-# end for name, mass_range in mass_bins:
+                if len(entry)==len(mc_samples):
+                    draw = '2'
+                    eff.SetLineColor(ROOT.kGreen+2)
+                    eff.SetFillColor(ROOT.kGreen+2)
+                    eff.SetFillStyle(1001)
+                    lg.AddEntry(eff,'All Simulation','LF')
+                else:
+                    raise ValueError("Set line+fill color, fill Style, and set legend entry for MC entry list")
+            #lg.AddEntry(eff, pretty.get(entry.name, entry.name), 'LF')
+            draw += same
+            eff.Draw(draw)
+            effs.append(eff)
+            same = ' same'
+            outfile.cd()
+            eff.Write("arp%d"%iarp)
+            iarp+=1
+        # end for entry in to_use[name]: # entry is a specific sample
+        lg.Draw()
+        name = nminus1+'_mass'
+        ps.save(name)
+        print(nminus1, pretty_name, name)
+    # end for name, mass_range in mass_bins:
+
+# ************************************************************************
+# Main
+# ************************************************************************
+if __name__=='__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='submits limits for a given mass')
+    parser.add_argument('--tag',help='Tagged directory name for input histograms and output plots',default='')
+    parser.add_argument('--stats',help='Print stats',default=False)
+    parser.add_argument('--lumi',help='Integrated luminosity in pb-1',default='1000')
+    parser.add_argument('--do_tight',help='Do tight cuts',default=False)
+    args = parser.parse_args()
+
+    # cjsbad - add a cmd-line option for dy only, qcd, zprime, etc
+    tag = args.tag
+    if not os.path.exists('plots/%s'%tag):
+        raise ValueError('Tagged directory %s does not exist!'%tag)
+
+    draw_mass_test(tag, args.stats, float(args.lumi), args.do_tight)
+

--- a/test/NMinus1Effs/draw_mass_stack.py
+++ b/test/NMinus1Effs/draw_mass_stack.py
@@ -1,519 +1,215 @@
 #!/usr/bin/env python
 
-# (py draw.py >! plots/nminus1effs/out.draw) && tlp plots/nminus1effs
+# Import nm1entry.py
+# - from MCSamples and roottools import *
+# - nm1entry class
+# - nminus1s list
+# - pretty dictionary
+# - styles dictionary
+from nm1entry import *
+ROOT.gROOT.SetBatch(True)
 
-from pprint import pprint
-import sys, os
-from array import array
-from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
-set_zp2mu_style()
-#ROOT.gStyle.SetPadTopMargin(0.02)
-ROOT.gStyle.SetPadRightMargin(0.02)
-#ROOT.gStyle.SetTitleX(0.12)
-#ROOT.gStyle.SetTitleH(0.07)
-ROOT.TH1.AddDirectory(0)
+def draw_mass_stack_test(tag, printStats, lumi, do_tight=False):
 
-outfile = ROOT.TFile("whargl.root","recreate")
-iarp=0
-do_tight = 'tight' in sys.argv
-#psn = 'plots/nminus1effs'
-psn = 'plots/paper2016'
-# 'plots' = '/afs/cern.ch/work/c/cschnaib/NMinus1Effs/plots/TAG/'
-if do_tight:
-    psn += '_tight'
-ps = plot_saver(psn, size=(800,600),log=True, pdf_log=True, name='')
-ps.c.SetTopMargin(0.075)
-ps.c.SetBottomMargin(0.1)
-ps.c.SetRightMargin(0.05)
-#ps.c.SetLeftMargin(0.03)
-ps.c.SetLogy(1)
+    # Specific stylings for this script on top of zp2mu_style
+    #ROOT.gStyle.SetPadTopMargin(0.02)
+    ROOT.gStyle.SetPadRightMargin(0.02)
+    #ROOT.gStyle.SetTitleX(0.12)
+    #ROOT.gStyle.SetTitleH(0.07)
+    #ROOT.gStyle.SetTitleX(0.25)
+    #ROOT.gStyle.SetTitleY(0.50)
+    ROOT.TH1.AddDirectory(0)
+    outfile = ROOT.TFile("whargl.root","recreate")
+    iarp=0
+
+    # 'plots' = '/afs/cern.ch/work/c/cschnaib/Zprime2muAnalysis/NMinus1Effs/plots/TAG/tag'
+    # TAG = MC/Data production TAG
+    # tag = sub tag for each version of plots made with a single production TAG
+    psn = 'plots'
+    if tag:
+        psn = 'plots/%s'%tag
+
+    # cjsbad - fix the referencing to tightnm1...
+    #if do_tight:
+    #    psn += '_tight'
+    #    nminus1s = tightnm1[:]
+
+    ps = plot_saver(psn, size=(600,600), log=False, pdf=True)
+    ps.c.SetBottomMargin(0.2)
+    ps.c.SetTopMargin(0.075)
+    ps.c.SetBottomMargin(0.1)
+    ps.c.SetRightMargin(0.05)
+    #ps.c.SetLeftMargin(0.03)
+    ps.c.SetLogy(1)
+
+    # cjsbad
+    # fix the data entry
+    data = nm1entry('data', True, lumi)
+
+    refXS = dy50to120.cross_section
+    refN = dy50to120.nevents
+    #print lumi, refN/refXS
+
+    # All MC samples
+    samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
+    mc_samples = [nm1entry(sample,False,lumi) for sample in samples]
+    #for mc_sample in mc_samples:
+    #    exec '%s = mc_sample' % mc_sample.name
+
+    #bin_width = 20
+    #maxX = 2500
+    #minX = 60
+    #nBins = (maxX-minX)/bin_width
+    #mass_range = []
+    #for i in range(3,nBins):
+    #    ibin = i*bin_width
+    #    mass_range.append(ibin)
+    #print mass_range
+    mass_range = [60,120,180,240,320,500,1000,2500]
+
+    to_use = {
+    #   'sample':[MC,Data],
+        'NoPt':[mc_samples,data],
+        'NoDB':[mc_samples,data],
+        'NoIso':[mc_samples,data],
+        'NoTkLayers':[mc_samples,data],
+        'NoPxHits':[mc_samples,data],
+        'NoMuHits':[mc_samples,data],
+        'NoMuMatch':[mc_samples,data],
+        'NoVtxProb':[mc_samples,data],
+        'NoB2B':[mc_samples,data],
+        'NoDptPt':[mc_samples,data],
+        'NoTrgMtch':[mc_samples,data],
+        }
 
 
-if do_tight:
-    nminus1s = [
-        #'TiPt',
-        'TiDB',
-        'TiGlbChi2',
-        'TiIso',
-        'TiTkLayers',
-        'TiPxHits',
-        'TiMuHits',
-        'TiMuMatch',
-        ]
-else:
-    nminus1s = [
-        'NoPt',
-        'NoDB',
-        'NoIso',
-        'NoTkLayers',
-        'NoPxHits',
-        'NoMuHits',
-        'NoMuMatch',
-        'NoVtxProb',
-        'NoB2B',
-        'NoDptPt',
-                #'NoCosm',
-        'NoTrgMtch',
-        ]
+    print nminus1s
+    for nminus1 in nminus1s:
+        pretty_name = pretty[nminus1]
+        print nminus1, pretty_name
+        lg = ROOT.TLegend(0.45, 0.55, 0.91, 0.9)
+        lg.SetTextSize(0.03)
+        lg.SetFillColor(0)
+        lg.SetBorderSize(1)
+        
+        same = 'A'
+        effs = []
 
-pretty = {
-    'NoPt': 'p_{T} > 53 GeV',
-    'NoTkLayers': '# tk lay > 5',
-    'NoPxHits': '# px hits > 0',
-    'NoMuStns': '# mu segs > 1',
-    'NoDB': '|dxy| < 0.2',
-    'NoGlbChi2': 'glb #chi^{2}/ndf < 10',
-    'NoTkMuon': 'isTrackerMuon',
-    'NoMuHits': '# mu hits > 0',
-    'NoMuMatch': '# matched stations > 1',
-    'NoCosm': 'anti-cosmic',
-    'NoTrgMtch': 'HLT match',
-    'NoB2B': 'back-to-back',
-    'NoVtxProb': '#chi^{2} #mu#mu vtx < 20',
-    'NoDptPt': 'dpT/pT',
-    'NoIso': 'rel. tk. iso.',
-    #'data': 'Data, %.1f fb^{-1}',
-    'data': 'Data, %.1f fb^{-1}, MuonOnly',
-    'dataB': 'Data RunB, %.1f fb^{-1}, MuonOnly',
-    'dataCD': 'Data RunC+D, %.1f fb^{-1}, MuonOnly',
-    'dataBCD': 'Data RunB+C+D, %.1f fb^{-1}, MuonOnly',
-    'mcsum_lumi': 'Simulation',
-    'mcsum_ref': 'Simulation',
-    'mc50m120_lumi': 'Simulation 60 < M < 120 GeV',
-    'mc50m120_ref': 'Simulation 60 < M < 120 GeV',
-    'mc120m_lumi': 'Simulation M > 120 GeV',
-    'mc120m_ref': 'Simulation M > 120 GeV',
-    'mc800m2300_lumi': 'Simulation 800 < M < 2300 GeV',
-    'mc800m2300_ref': 'Simulation 800 < M < 2300 GeV',
-    'mc400m2300_lumi': 'Simulation 400 < M < 2300 GeV',
-    'mc400m2300_ref': 'Simulation 400 < M < 2300 GeV',
-    'zmumu': 'Z#rightarrow#mu#mu, 60 < M < 120 GeV',
-    'dy120_c1': 'DY#rightarrow#mu#mu, M > 120 GeV',
-    'dy200_c1': 'DY#rightarrow#mu#mu, M > 200 GeV',
-    'dy500_c1': 'DY#rightarrow#mu#mu, M > 500 GeV',
-    'dy1000_c1': 'DY#rightarrow#mu#mu, M > 1000 GeV',
-    'dy50': 'DY#rightarrow#mu#mu madgraph',
-#    'dy50': 'DY#rightarrow#mu#mu, M > 50 GeV',
-    'dy50to120': 'DY#rightarrow#mu#mu 50 < m < 120 GeV',
-    'dy120to200': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
-    'dy200to400': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
-    'dy400to800': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
-    'dy800to1400': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
-    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
-    'dy2300to3500': 'DY#rightarrow#mu#mu 2300 < m < 3500 GeV',
-    'dy3500to4500': 'DY#rightarrow#mu#mu 3500 < m < 4500 GeV',
-    'dy4500to6000': 'DY#rightarrow#mu#mu 4500 < m < 6000 GeV',
-    'dy50_startup': 'DY#rightarrow#mu#mu startup',
-    'ttbar': 't#bar{t}',
-    'ttbar_pow': 't#bar{t} powheg',
-    'ttbar_startup': 't#bar{t} startup',
-    'ww_incl': 'WW',
-    'zz_incl': 'ZZ',
-    'wz' : 'WZ',
-    'inclmu15': 'QCD',
-    'zssm1000': 'Z\' SSM, M=1000 GeV',
-    'zpsi5000': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_m1TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_1m3TeV': 'Z\'_{#psi}, M=5000 GeV',
-    'zpsi5000_3mTeV': 'Z\'_{#psi}, M=5000 GeV',
-    '60m120_BCD': '60 < m < 120 GeV',
-    '60m120_CD': '60 < m < 120 GeV',
-    '60m120': '60 < m < 120 GeV',
-    '70m110': '70 < m < 110 GeV',
-    '120m200': '120 < m < 200 GeV', 
-    '200m400': '200 < m < 400 GeV',
-    '400m600': '400 < m < 600 GeV',
-    '200m': 'm > 200 GeV',
-    '50m': 'm > 50 GeV',
-    '70m': 'm > 70 GeV',
-    '120m_BCD': 'm > 120 GeV',
-    '120m_CD': 'm > 120 GeV',
-    '120m': 'm > 120 GeV',
-    'DY120to200Powheg': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
-    'DY200to400Powheg': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
-    'DY400to800Powheg': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
-    'DY800to1400Powheg': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
-    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
-    '400m800' : '400 < m < 800 GeV',
-    '800m1400': '800 < m < 1400 GeV',
-    '1400m2300':'1400 < m < 2300 GeV',
-    '800m2300':'800 < m < 2300 GeV',
-    '400m2300':'400 < m < 2300 GeV',
-    'all_lumi':'Simulation M > 120 GeV',
-    'all_ref':'Simulation M > 120 GeV',
-    '120m1400':'120 < M < 1400 GeV',
-    }
-
-class nm1entry:
-    def __init__(self, sample, is_data, lumi):
-        if type(sample) == str:
-            self.name = sample
-            self.fn = 'data/ana_nminus1_%s.root'%sample
-            #self.fn = self.make_fn(sample,is_data) if is_data else None
-            self.lumi = lumi if is_data else None
-            self.is_data = is_data
-        else:
-            self.name = sample.name
-            self.fn = self.make_fn(self.name,is_data)
-            self.partial_weight = sample.partial_weight
-            self.is_data = is_data
-        self.prepare_histos()
-            
-    def make_fn(self, name, is_data):
-        '''
-        if is_data==True:
-            return 'data/ana_nminus1_%s.root' %name
-        else:
-        '''
-        return 'mc/ana_nminus1_%s.root' % name
-    
-    def prepare_histos(self):
-        self.histos = {}
-        if self.fn is not None:
-            f = ROOT.TFile(self.fn)
-            for nminus1 in nminus1s + ['NoNo']:
-                if nminus1=='NoVtxProb':
-                    self.histos[nminus1] = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()#DileptonMass
-
-    def prepare_histos_sum(self, samples, lumi):
-        self.histos = {}
-        for nminus1 in nminus1s + ['NoNo']:
-            #hs = []
-            #print '%20s%20s%21s%20s%20s' % ('cut', 'sampe name', 'partial weight', 'scale(ref)','scale(lumi)')
-            for sample in samples:
-                f = ROOT.TFile(self.make_fn(sample.name,is_data))
-                if nminus1 == 'NoVtxProb':
-                    h = f.Get(nminus1).Get('DileptonMass').Clone()
-                else:
-                    h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
-                #print '%20s%20s%20.15f%20f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS, lumiBCD)
-                # partial_weight = cross_section * k_factor / Nevents
-                if lumi>0:
-                    # scale to luminosity for comparision of single dataset to MC
-                    h.Scale(sample.partial_weight * lumi) 
-                    #print nminus1, sample.name, sample.partial_weight*lumi
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, lumi)
-                if lumi<0:
-                    # scale to reference cross section/Nevents for comparision of multiple datasets to MC
-                    h.Scale(sample.partial_weight * refN / refXS)  
-                    #print nminus1, sample.name, sample.partial_weight*refN/refXS
-                    #print '%20s%20s%20.10f%20f' % (nminus1, sample.name, sample.partial_weight, refN/refXS)
-                #hs.append(h)
-            #hsum = hs[0].Clone()
-            #for h in hs[1:]:
-            #    hsum.Add(h)
-            self.histos[nminus1] = h
-
-#data, lumi = nm1entry('data', True), 242.8 # lumi in pb
-nolumi = -1
-lumiB = 50.7 
-lumiCD = 2619.44
-lumiD = 2572.19
-#lumiBCD = 2660.14
-lumiBCD = 2800.
-#dataB = nm1entry('dataB', True, lumiB)#lumiB )
-#dataCD = nm1entry('dataCD', True, lumiCD)#lumiCD )
-dataBCD = nm1entry('dataBCD', True, lumiBCD)#lumiCD )
-#dataD = nm1entry('dataD', True, lumiD )
-#mcsum_lumi = nm1entry('mcsum_lumi',False,lumiBCD)
-#mcsum_ref = nm1entry('mcsum_ref',False,nolumi)
-#DYmc = nm1entry('DYmc',False,lumiBCD)
-#nonDYmc = nm1entry('nonDYmc',False,lumiBCD)
-#wjets = nm1entry('wjets',False,lumiBCD)
-
-from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
-#raw_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop]
-raw_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,ttbar_pow,ww_incl,zz_incl,wz,tWtop,tWantitop,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
-#use_samples = [tWtop,tWantitop,ww_incl,wz,zz_incl,ttbar_pow,dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000]
-use_samples = [dy50to120,dy120to200,dy200to400,dy400to800,dy800to1400,dy1400to2300,dy2300to3500,dy3500to4500,dy4500to6000,tWtop,tWantitop,ww_incl,wz,zz_incl,ttbar_pow,qcd80to120,qcd120to170,qcd170to300,qcd300to470,qcd470to600,qcd600to800,qcd800to1000,qcd1000to1400,qcd1400to1800,qcd1800to2400,qcd2400to3200,qcd3200,wjets]
-
-refXS = dy50to120.cross_section
-refN = dy50to120.nevents
-print lumiBCD, refN/refXS
-
-# All MC samples
-# lumi
-#mc_samples.prepare_histos_sum(use_samples,lumiBCD)
-mc_samples = [nm1entry(sample,False,lumiBCD) for sample in use_samples]
-for mc_sample in mc_samples:
-    exec '%s = mc_sample' % mc_sample.name
-# ref
-#mcsum_ref.prepare_histos_sum(use_samples, nolumi) 
-#mc_samples_ref = [nm1entry(sample,False,nolumi) for sample in use_samples]
-#for mc_sample in mc_samples_ref:
-#    exec '%s = mc_sample' % mc_sample.name
-
-#bin_width = 20
-#maxX = 2500
-#minX = 60
-#nBins = (maxX-minX)/bin_width
-#mass_range = []
-#for i in range(3,nBins):
-#    ibin = i*bin_width
-#    mass_range.append(ibin)
-#print mass_range
-mass_range = [60,120,180,240,320,500,1000,2500]
-
-to_use = {
-#   'sample':[MC,Data],
-    #'NoPt':[DYmc,nonDYmc,dataCD],
-    #'NoDB':[DYmc,nonDYmc,dataCD],
-    #'NoIso':[DYmc,nonDYmc,dataCD],
-    #'NoTkLayers':[DYmc,nonDYmc,dataCD],
-    #'NoPxHits':[DYmc,nonDYmc,dataCD],
-    #'NoMuHits':[DYmc,nonDYmc,dataCD],
-    #'NoMuMatch':[DYmc,nonDYmc,dataCD],
-    #'NoVtxProb':[DYmc,nonDYmc,dataCD],
-    #'NoB2B':[DYmc,nonDYmc,dataCD],
-    #'NoDptPt':[DYmc,nonDYmc,dataCD],
-    #'NoTrgMtch':[DYmc,nonDYmc,dataCD],
-
-    #'NoPt#':[mcsum_lumi,dataCD],
-    #'NoDB#':[mcsum_lumi,dataCD],
-    #'NoIso#':[mcsum_lumi,dataCD],
-    #'NoTkLayers#':[mcsum_lumi,dataCD],
-    #'NoPxHits#':[mcsum_lumi,dataCD],
-    #'NoMuHits#':[mcsum_lumi,dataCD],
-    #'NoMuMatch#':[mcsum_lumi,dataCD],
-    #'NoVtxProb#':[mcsum_lumi,dataCD],
-    #'NoB2B#':[mcsum_lumi,dataCD],
-    #'NoDptPt#':[mcsum_lumi,dataCD],
-    #'NoTrgMtch#':[mc_samples,dataCD],
-    'NoPt':[mc_samples,dataBCD],
-    'NoDB':[mc_samples,dataBCD],
-    'NoIso':[mc_samples,dataBCD],
-    'NoTkLayers':[mc_samples,dataBCD],
-    'NoPxHits':[mc_samples,dataBCD],
-    'NoMuHits':[mc_samples,dataBCD],
-    'NoMuMatch':[mc_samples,dataBCD],
-    'NoVtxProb':[mc_samples,dataBCD],
-    'NoB2B':[mc_samples,dataBCD],
-    'NoDptPt':[mc_samples,dataBCD],
-    'NoTrgMtch':[mc_samples,dataBCD],
-    }
-
-styles = {
-#    'sample':    (color, draw/fill style),
-    'dataB':      (ROOT.kBlack,     -1),
-    'dataCD':      (ROOT.kBlack,     -1),
-    'dataBCD':      (ROOT.kBlack,     -1),
-    'dy50to120':(ROOT.kGreen+2, 1001),
-    'dy120to200':(ROOT.kGreen+2, 1001),
-    'dy200to400':(ROOT.kGreen+2, 1001),
-    'dy400to800':(ROOT.kGreen+2, 1001),
-    'dy800to1400':(ROOT.kGreen+2, 1001),
-    'dy1400to2300':(ROOT.kGreen+2, 1001),
-    'dy2300to3500':(ROOT.kGreen+2, 1001),
-    'dy3500to4500':(ROOT.kGreen+2, 1001),
-    'dy4500to6000':(ROOT.kGreen+2, 1001),
-    #'dy50to120':(ROOT.kGreen+2, 1001),
-    #'dy120to200':(ROOT.kBlue, 1001),
-    #'dy200to400':(ROOT.kRed, 1001),
-    #'dy400to800':(ROOT.kYellow, 1001),
-    #'dy800to1400':(ROOT.kSpring, 1001),
-    #'dy1400to2300':(ROOT.kCyan, 1001),
-    #'dy2300to3500':(ROOT.kPink, 1001),
-    #'dy3500to4500':(ROOT.kOrange, 1001),
-    #'dy4500to6000':(ROOT.kTeal-6, 1001),
-    #'dy6000_s':(ROOT.kGreen+3, 1001),
-    'ttbar_pow':(ROOT.kBlue,1001),
-    'ww_incl':(ROOT.kOrange,1001),
-    'zz_incl':(ROOT.kOrange,1001),
-    'wz':(ROOT.kOrange,1001),
-    'tWtop':(ROOT.kYellow,1001),
-    'tWantitop':(ROOT.kYellow,1001),
-    'wjets':(ROOT.kViolet,1001),
-    'qcd50to80':(ROOT.kViolet,1001),
-    'qcd80to120':(ROOT.kViolet,1001),
-    'qcd120to170':(ROOT.kViolet,1001),
-    'qcd170to300':(ROOT.kViolet,1001),
-    'qcd300to470':(ROOT.kViolet,1001),
-    'qcd470to600':(ROOT.kViolet,1001),
-    'qcd600to800':(ROOT.kViolet,1001),
-    'qcd800to1000':(ROOT.kViolet,1001),
-    'qcd1000to1400':(ROOT.kViolet,1001),
-    'qcd1400to1800':(ROOT.kViolet,1001),
-    'qcd1800to2400':(ROOT.kViolet,1001),
-    'qcd2400to3200':(ROOT.kViolet,1001),
-    'qcd3200':(ROOT.kViolet,1001),
-    }
-
-#yrange = {
-#   'sample':    (ymin,ymax),
-#    'NoPt':      (0.00,1.01),
-#    'NoDB':      (0.95,1.001),
-#    'NoIso':     (0.6,1.01),
-#    'NoTkLayers':(0.95,1.001),
-#    'NoPxHits':  (0.95,1.001),
-#    'NoMuHits':  (0.95,1.001),
-#    'NoMuMatch': (0.35,1.005),
-#    'NoVtxProb': (0.90,1.001),
-#    'NoB2B':     (0.95,1.001),
-#    'NoDptPt':   (0.95,1.001),
-#    'NoTrgMtch': (0.95,1.001),
-#    }
-#global_ymin = 0.
-global_ymin = None
-
-def table_wald(entry,nminus1, mass_range):
-    print entry.name
-    hnum = entry.histos['NoNo']
-    hden = entry.histos[nminus1]
-    print '%20s%27s%23s%20s%16s%25s%26s' % ('cut', 'mass range','numerator', 'denominator', 'efficiency', '- 68% CL-CP +','68% CL-Wald')
-    for mbin in range(len(mass_range)):
-        if mbin == (len(mass_range)-1): break
-        mlow = mass_range[mbin]
-        mhigh = mass_range[mbin+1] 
-        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-        pcp,lcp,hcp = clopper_pearson(num, den)
-        if num==0 and den==0:
-            eff = 0
-            errw = 0
-        else:
-            eff = num/den
-            if (eff*(1-eff))<0:
-                print "what is this"
-                print nminus1, entry.name, mlow, mhigh, num, den
-            else:
-                errw = (eff*(1-eff)/den)**0.5
-        print '%20s%15i%15i%20f%20f%15f%15f%15f%23f'     % (nminus1, mlow, mhigh, num, den, eff, eff-lcp, hcp-eff,        errw)
-        print '%20s%15i%15i%20f%20f%15f%15f%15f%15f%16f' % (nminus1, mlow, mhigh, num, den, eff, lcp,     hcp,     eff-errw, eff+errw)
-        print ' '
-    print '---------------------------------------------'
-
-def table(entry,nminus1, mass_range):
-    print entry.name
-    hnum = entry.histos['NoNo']
-    hden = entry.histos[nminus1]
-    print '%20s%27s%23s%20s%20s%22s' % ('cut', 'mass range', 'numerator', 'denominator', 'efficiency', '68% CL')
-    for mbin in range(len(mass_range)):
-        if mbin == (len(mass_range)-1): break
-        mlow = mass_range[mbin]
-        mhigh = mass_range[mbin+1] 
-        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-        e,l,h = clopper_pearson(num, den)
-        print '%20s%15i%15i%20f%20f%20f%15f%15f' % (nminus1, mlow, mhigh, num, den, p_hat, p_hat_e, p_hat_e)
-
-#ROOT.gStyle.SetTitleX(0.25)
-#ROOT.gStyle.SetTitleY(0.50)
-
-for nminus1 in nminus1s:
-    pretty_name = pretty[nminus1]
-    print nminus1, pretty_name
-    lg = ROOT.TLegend(0.45, 0.55, 0.91, 0.9)
-    lg.SetTextSize(0.03)
-    lg.SetFillColor(0)
-    lg.SetBorderSize(1)
-    
-    same = 'A'
-    effs = []
-
-    stack_num = ROOT.THStack('hs','')
-    stack_den = ROOT.THStack('hs','')
+        stack_num = ROOT.THStack('hs','')
+        stack_den = ROOT.THStack('hs','')
 
 
 
-    for entry in to_use[nminus1]: #,mass_range 
+        for entry in to_use[nminus1]: #,mass_range 
 
-        #table(entry,nminus1, mass_range)
+            l = len(mass_range)-1
+            data_num = ROOT.TH1F('num', '', l, array('f',mass_range))
+            data_den = ROOT.TH1F('den', '', l, array('f',mass_range))
 
-        l = len(mass_range)-1
-
-        data_num = ROOT.TH1F('num', '', l, array('f',mass_range))
-        data_den = ROOT.TH1F('den', '', l, array('f',mass_range))
-
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            #table_wald(entry,nminus1,mass_range)
-            color, fill = styles[entry.name]
-            hnum = entry.histos['NoNo']
-            hden = entry.histos[nminus1]
-            for mbin in range(len(mass_range)):
-                if mbin == (len(mass_range)-1): continue
-                mlow = mass_range[mbin]
-                mhigh = mass_range[mbin+1]
-                num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-                den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-                #nminus1_num.SetBinContent(mbin+1, num)
-                data_num.SetBinContent(mbin+1, num)
-                data_den.SetBinContent(mbin+1, den)
-            #eff,p,epl,eph = binomial_divide(nminus1_num, nminus1_den)
-        else:
-            #for a,mc in enumerate(entry):
-            #    table_wald(mc,nminus1,mass_range)
-            for i,mc in enumerate(entry):
-                nminus1_den_MC = ROOT.TH1F('den', '', l, array('f',mass_range))
-                nminus1_num_MC = ROOT.TH1F('num', '', l, array('f',mass_range))
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                if printStats: table(entry,nminus1, mass_range)
+                color, fill = styles[entry.name]
+                hnum = entry.histos['NoNo']
+                hden = entry.histos[nminus1]
                 for mbin in range(len(mass_range)):
                     if mbin == (len(mass_range)-1): continue
-                    hnum = mc.histos['NoNo']
-                    hden = mc.histos[nminus1]
                     mlow = mass_range[mbin]
                     mhigh = mass_range[mbin+1]
-                    num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
-                    den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
-                    #den*mc.partial_weight*lumiBCD
-                    nminus1_num_MC.SetBinContent(mbin+1, num)
-                    nminus1_den_MC.SetBinContent(mbin+1, den)
-                color, fill = styles[mc.name]
-                nminus1_num_MC.SetLineColor(color)
-                nminus1_num_MC.SetFillColor(color)
-                nminus1_num_MC.SetMinimum(1E-7)
-                #nminus1_num_MC.Scale(mc.partial_weight*refN/refXS)
-                nminus1_num_MC.Scale(mc.partial_weight*lumiBCD)
-                stack_num.Add(nminus1_num_MC)
-                nminus1_den_MC.SetLineColor(color)
-                nminus1_den_MC.SetFillColor(color)
-                #nminus1_den_MC.Scale(mc.partial_weight*refN/refXS)
-                nminus1_den_MC.Scale(mc.partial_weight*lumiBCD)
-                stack_den.Add(nminus1_den_MC)
-                #lg.AddEntry(nminus1_den_MC,pretty.get(mc.name,mc.name),"F")
-                if mc.name == 'dy50to120':
-                    lg.AddEntry(nminus1_den_MC,"Drell-Yan",'F' )
-                elif mc.name == 'ttbar_pow':
-                    lg.AddEntry(nminus1_den_MC,"t#bar{t}","F")
-                elif mc.name == 'ww_incl':
-                    lg.AddEntry(nminus1_den_MC,"DiBoson","F")
-                elif mc.name == 'qcd80to120':
-                    lg.AddEntry(nminus1_den_MC,"QCD & W+jets","F")
-                elif mc.name == 'tWtop':
-                    lg.AddEntry(nminus1_den_MC,"Single Top","F")
-        if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
-            draw = 'P'
-            data_num.SetLineColor(color)
-            data_num.SetMarkerStyle(20)
-            data_num.SetMarkerSize(1.05)
-            data_num.SetMarkerColor(color)
-            data_den.SetLineColor(color)
-            data_den.SetMarkerStyle(20)
-            data_den.SetMarkerSize(1.05)
-            data_den.SetMarkerColor(color)
-            #lg.AddEntry(data, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
-            lg.AddEntry(data_den, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
-    #stack_num.SetMinimum(1E-7)
-    stack_num.Draw("hist")
-    data_num.Draw("pe1same")
-    lg.Draw()
-    outfile.cd()
-    #stack_num.SetMinimum(0.1)
-    stack_num.SetTitle("All Selection Applied")
-    stack_num.GetXaxis().SetTitle("m(#mu^{+}#mu^{-}) [GeV]")
-    #stack_num.GetXaxis().SetTitle("p_{T}(#mu) [GeV]")
-    stack_num.GetYaxis().SetTitle("Events")
-    ps.save(nminus1+'_stack_mass_num')
-    print
-    stack_den.Draw("hist")
-    data_den.Draw("pe1same")
-    lg.Draw()
-    outfile.cd()
-    stack_den.SetMinimum(0.1)
-    stack_den.SetTitle("N - ("+pretty_name+")")
-    stack_den.GetXaxis().SetTitle("m(#mu^{+}#mu^{-}) [GeV]")
-    #stack_den.GetXaxis().SetTitle("p_{T}(#mu) [GeV]")
-    stack_den.GetYaxis().SetTitle("Events")
-    ps.save(nminus1+'_stack_mass_den')
-    print
-# end for name, mass_range in mass_bins:
+                    num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                    den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                    data_num.SetBinContent(mbin+1, num)
+                    data_den.SetBinContent(mbin+1, den)
+            else:
+                if printStats: table_wald(mc,nminus1,mass_range)
+                for i,mc in enumerate(entry):
+                    nminus1_den_MC = ROOT.TH1F('den', '', l, array('f',mass_range))
+                    nminus1_num_MC = ROOT.TH1F('num', '', l, array('f',mass_range))
+                    for mbin in range(len(mass_range)):
+                        if mbin == (len(mass_range)-1): continue
+                        hnum = mc.histos['NoNo']
+                        hden = mc.histos[nminus1]
+                        mlow = mass_range[mbin]
+                        mhigh = mass_range[mbin+1]
+                        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False, nm1=True)
+                        nminus1_num_MC.SetBinContent(mbin+1, num)
+                        nminus1_den_MC.SetBinContent(mbin+1, den)
+                    color, fill = styles[mc.name]
+                    nminus1_num_MC.SetLineColor(color)
+                    nminus1_num_MC.SetFillColor(color)
+                    nminus1_num_MC.SetMinimum(1E-7)
+                    #nminus1_num_MC.Scale(mc.partial_weight*refN/refXS)
+                    nminus1_num_MC.Scale(mc.partial_weight*lumi)
+                    stack_num.Add(nminus1_num_MC)
+                    nminus1_den_MC.SetLineColor(color)
+                    nminus1_den_MC.SetFillColor(color)
+                    #nminus1_den_MC.Scale(mc.partial_weight*refN/refXS)
+                    nminus1_den_MC.Scale(mc.partial_weight*lumi)
+                    stack_den.Add(nminus1_den_MC)
+                    #lg.AddEntry(nminus1_den_MC,pretty.get(mc.name,mc.name),"F")
+                    if mc.name == 'dy50to120':
+                        lg.AddEntry(nminus1_den_MC,"Drell-Yan",'F' )
+                    elif mc.name == 'ttbar_pow':
+                        lg.AddEntry(nminus1_den_MC,"t#bar{t}","F")
+                    elif mc.name == 'ww_incl':
+                        lg.AddEntry(nminus1_den_MC,"DiBoson","F")
+                    elif mc.name == 'qcd80to120':
+                        lg.AddEntry(nminus1_den_MC,"QCD & W+jets","F")
+                    elif mc.name == 'tWtop':
+                        lg.AddEntry(nminus1_den_MC,"Single Top","F")
+            if not isinstance(entry,(list,tuple)) and 'data' in entry.name:
+                draw = 'P'
+                data_num.SetLineColor(color)
+                data_num.SetMarkerStyle(20)
+                data_num.SetMarkerSize(1.05)
+                data_num.SetMarkerColor(color)
+                data_den.SetLineColor(color)
+                data_den.SetMarkerStyle(20)
+                data_den.SetMarkerSize(1.05)
+                data_den.SetMarkerColor(color)
+                #lg.AddEntry(data, pretty.get(entry.name, entry.name) % (lumi/1000.), 'LP')
+                lg.AddEntry(data_den, pretty.get(entry.name, entry.name) % (entry.lumi/1000.), 'LP')
+        #stack_num.SetMinimum(1E-7)
+        stack_num.Draw("hist")
+        data_num.Draw("pe1same")
+        lg.Draw()
+        outfile.cd()
+        #stack_num.SetMinimum(0.1)
+        stack_num.SetTitle("All Selection Applied")
+        stack_num.GetXaxis().SetTitle("m(#mu^{+}#mu^{-}) [GeV]")
+        #stack_num.GetXaxis().SetTitle("p_{T}(#mu) [GeV]")
+        stack_num.GetYaxis().SetTitle("Events")
+        numName = nminus1+'_stack_mass_num'
+        ps.save(numName)
+        stack_den.Draw("hist")
+        data_den.Draw("pe1same")
+        lg.Draw()
+        outfile.cd()
+        stack_den.SetMinimum(0.1)
+        stack_den.SetTitle("N - ("+pretty_name+")")
+        stack_den.GetXaxis().SetTitle("m(#mu^{+}#mu^{-}) [GeV]")
+        #stack_den.GetXaxis().SetTitle("p_{T}(#mu) [GeV]")
+        stack_den.GetYaxis().SetTitle("Events")
+        denName = nminus1+'_stack_mass_den'
+        ps.save(denName)
+        print(nminus1, pretty_name, denName, numName)
+    # end for name, mass_range in mass_bins:
+
+# ************************************************************************
+# Main
+# ************************************************************************
+if __name__=='__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='submits limits for a given mass')
+    parser.add_argument('--tag',help='Tagged directory name for input histograms and output plots',default='')
+    parser.add_argument('--stats',help='Print stats',default=False)
+    parser.add_argument('--lumi',help='Integrated luminosity in pb-1',default='1000')
+    parser.add_argument('--do_tight',help='Do tight cuts',default=False)
+    args = parser.parse_args()
+
+    tag = args.tag
+    if not os.path.exists('plots/%s'%tag):
+        raise ValueError('Tagged directory %s does not exist!'%tag)
+
+    draw_mass_stack_test(tag, args.stats, float(args.lumi), args.do_tight)
+

--- a/test/NMinus1Effs/nm1entry.py
+++ b/test/NMinus1Effs/nm1entry.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+
+# Imports and style settings to be applied to all scripts
+from pprint import pprint
+import sys, os
+from array import array
+import numpy as np
+from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
+from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
+set_zp2mu_style()
+
+lumiBCD = 2800.
+
+styles = {
+#    'sample':    (color, draw/fill style),
+    'dataB':      (ROOT.kBlack,     -1),
+    'dataCD':      (ROOT.kBlack,     -1),
+    'dataBCD':      (ROOT.kBlack,     -1),
+    'mc_samples_50m120': (ROOT.kGreen+2,1001),
+    'mc_samples_120m': (ROOT.kGreen+2,1001),
+    #'dy50to120':(ROOT.kGreen, 1001),
+    #'dy120to200':(ROOT.kGreen-4, 1001),
+    #'dy200to400':(ROOT.kGreen+1, 1001),
+    #'dy400to800':(ROOT.kGreen-7, 1001),
+    #'dy800to1400':(ROOT.kGreen-3, 1001),
+    #'dy1400to2300':(ROOT.kGreen+2, 1001),
+    #'dy2300to3500':(ROOT.kGreen-9, 1001),
+    #'dy3500to4500':(ROOT.kGreen-6, 1001),
+    #'dy4500to6000':(ROOT.kGreen-2, 1001),
+    'dy50to120':(ROOT.kGreen+2, 1001),
+    'dy120to200':(ROOT.kGreen+2, 1001),
+    'dy200to400':(ROOT.kGreen+2, 1001),
+    'dy400to800':(ROOT.kGreen+2, 1001),
+    'dy800to1400':(ROOT.kGreen+2, 1001),
+    'dy1400to2300':(ROOT.kGreen+2, 1001),
+    'dy2300to3500':(ROOT.kGreen+2, 1001),
+    'dy3500to4500':(ROOT.kGreen+2, 1001),
+    'dy4500to6000':(ROOT.kGreen+2, 1001),
+    'dy6000':(ROOT.kGreen+2, 1001),
+    'ttbar_pow':(ROOT.kBlue,1001),
+    'ww_incl':(ROOT.kOrange,1001),
+    'zz_incl':(ROOT.kOrange,1001),
+    'wz':(ROOT.kOrange,1001),
+    'tWtop':(ROOT.kYellow,1001),
+    'tWantitop':(ROOT.kYellow,1001),
+    'wjets':(ROOT.kViolet,1001),
+    'qcd50to80':(ROOT.kViolet,1001),
+    'qcd80to120':(ROOT.kViolet,1001),
+    'qcd120to170':(ROOT.kViolet,1001),
+    'qcd170to300':(ROOT.kViolet,1001),
+    'qcd300to470':(ROOT.kViolet,1001),
+    'qcd470to600':(ROOT.kViolet,1001),
+    'qcd600to800':(ROOT.kViolet,1001),
+    'qcd800to1000':(ROOT.kViolet,1001),
+    'qcd1000to1400':(ROOT.kViolet,1001),
+    'qcd1400to1800':(ROOT.kViolet,1001),
+    'qcd1800to2400':(ROOT.kViolet,1001),
+    'qcd2400to3200':(ROOT.kViolet,1001),
+    'qcd3200':(ROOT.kViolet,1001),
+}
+
+nminus1s = [
+    'NoPt',
+    'NoDB',
+    'NoIso',
+    'NoTkLayers',
+    'NoPxHits',
+    'NoMuHits',
+    'NoMuMatch',
+    'NoVtxProb',
+    'NoB2B',
+    'NoDptPt',
+    #'NoCosm',
+    'NoTrgMtch',
+    ]
+
+tightnm1 = [
+    #'TiPt',
+    'TiDB',
+    'TiGlbChi2',
+    'TiIso',
+    'TiTkLayers',
+    'TiPxHits',
+    'TiMuHits',
+    'TiMuMatch',
+    ]
+
+pretty = {
+    'NoPt': 'p_{T} > 53 GeV',
+    'NoTkLayers': '# tk lay > 5',
+    'NoPxHits': '# px hits > 0',
+    'NoMuStns': '# mu segs > 1',
+    'NoDB': '|dxy| < 0.2',
+    'NoGlbChi2': 'glb #chi^{2}/ndf < 10',
+    'NoTkMuon': 'isTrackerMuon',
+    'NoMuHits': '# mu hits > 0',
+    'NoMuMatch': '# matched stations > 1',
+    'NoCosm': 'anti-cosmic',
+    'NoTrgMtch': 'HLT match',
+    'NoB2B': 'back-to-back',
+    'NoVtxProb': '#chi^{2} #mu#mu vtx < 20',
+    'NoDptPt': 'dpT/pT',
+    'NoIso': 'rel. tk. iso.',
+    'NoNo': 'All Selection',
+    #'data': 'Data, %.1f fb^{-1}',
+    'data': 'Data, %.1f fb^{-1}, MuonOnly',
+    'dataB': 'Data RunB, %.1f fb^{-1}, MuonOnly',
+    'dataCD': 'Data RunC+D, %.1f fb^{-1}, MuonOnly',
+    'dataBCD': 'Data, %.1f fb^{-1}, 2015 MuonOnly',
+    '120m': 'm > 120 GeV',
+    '60m120': '60 < m < 120 GeV',
+    'zpsi5000': 'Z\'_{#psi}, M=5000 GeV',
+    'dy50to120': 'DY#rightarrow#mu#mu 50 < m < 120 GeV',
+    'dy120to200': 'DY#rightarrow#mu#mu 120 < m < 200 GeV',
+    'dy200to400': 'DY#rightarrow#mu#mu 200 < m < 400 GeV',
+    'dy400to800': 'DY#rightarrow#mu#mu 400 < m < 800 GeV',
+    'dy800to1400': 'DY#rightarrow#mu#mu 800 < m < 1400 GeV',
+    'dy1400to2300': 'DY#rightarrow#mu#mu 1400 < m < 2300 GeV',
+    'dy2300to3500': 'DY#rightarrow#mu#mu 2300 < m < 3500 GeV',
+    'dy3500to4500': 'DY#rightarrow#mu#mu 3500 < m < 4500 GeV',
+    'dy4500to6000': 'DY#rightarrow#mu#mu 4500 < m < 6000 GeV',
+    'dy6000': 'DY#rightarrow#mu#mu m > 6000 GeV',
+    'ttbar_pow': 't#bar{t} powheg',
+    'ww_incl': 'WW',
+    'zz_incl': 'ZZ',
+    'wz' : 'WZ',
+    'tWtop': 'tW^{-}',
+    'tWantitop': '#bar{t}W^{+}',
+    'wjets': 'W + jets',
+    'qcd50to80': 'QCD 50 < p_{T}(#mu) < 80 GeV',
+    'qcd80to120': 'QCD 80 < p_{T}(#mu) < 120 GeV',
+    'qcd120to170': 'QCD 120 < p_{T}(#mu) < 170 GeV',
+    'qcd170to300': 'QCD 170 < p_{T}(#mu) < 300 GeV',
+    'qcd300to470': 'QCD 300 < p_{T}(#mu) < 470 GeV',
+    'qcd470to600': 'QCD 470 < p_{T}(#mu) < 600 GeV',
+    'qcd600to800': 'QCD 600 < p_{T}(#mu) < 800 GeV',
+    'qcd800to1000': 'QCD 800 < p_{T}(#mu) < 1000 GeV',
+    'qcd1000to1400': 'QCD 1000 < p_{T}(#mu) < 1400 GeV',
+    'qcd1400to1800': 'QCD 1400 < p_{T}(#mu) < 1800 GeV',
+    'qcd1800to2400': 'QCD 1800 < p_{T}(#mu) < 2400 GeV',
+    'qcd2400to3200': 'QCD 2400 < p_{T}(#mu) < 3200 GeV',
+    'qcd3200': 'QCD p_{T}(#mu) < 3200 GeV',
+    'inclmu15': 'QCD',
+}
+
+def wald_binomial_err2(p_hat, pw, den):
+    return float(p_hat) * (1 - float(p_hat)) / (float(den)/pw) # den is pre-weighted number of MC events
+
+def eff_wald(num, den, l, nMC, pw,temp):
+    '''
+    - Only used in NMinus1Effs/draw.py
+    - Inputs
+        - num = Numerator MC histogram (per NM1 eff)
+        - den = Denominator MC histogram (per NM1 eff)
+        - l = len(nminus1s)
+        - nMC = len(entry), entry = [dy50to120, ...]
+        - pw = [dy50to120.partial_weight*lumi, ...]
+        - temp = ROOT.TH1F('temp','',l,0,l)
+    - Output
+        - MC N-1 Histogram with Wald-Approx. uncertainties
+        - Array of effs and +/- uncertainties for each NM1 bin
+    '''
+    nbins = temp.GetNbinsX()
+    xax = temp.GetXaxis()
+    x = []
+    y = []
+    exl = []
+    exh = []
+    eyl = []
+    eyh = []
+    numTot = sum(e*f for e,f in zip(pw,num))
+    for i in range(l): # i = NoX
+        ibin = i+1
+        x.append(xax.GetBinCenter(ibin))
+        exl.append(xax.GetBinWidth(ibin)/2)
+        exh.append(xax.GetBinWidth(ibin)/2)
+        denTot_i = 0
+        sum_err2_i = 0
+        err2_i = []
+        denTot_i = sum([b*c for b,c in zip(pw,[a[i] for a in den])])
+        if numTot>denTot_i:
+            print "in eff_wald(): numTot>denTot, setting eff=1 ",numTot,denTot_i
+            y.append(1.)
+        elif denTot_i!=0:
+            y.append(numTot/denTot_i)
+        else: 
+            print "in eff_wald(): denTot_i==0 ?, setting eff=0",denTot_i
+            y.append(0.)
+        for mc in range(nMC): 
+            #print float(num[mc]), den[mc][i]
+            p_hat_i_mc = 0
+            if num[mc] != 0:
+                p_hat_i_mc = float(num[mc])/den[mc][i] # mc = mc sample, i = NoX
+                err2_i.append((pw[mc]*den[mc][i]/denTot_i)**2 * wald_binomial_err2(p_hat_i_mc,1., den[mc][i]))
+            else:
+                p_hat_i_mc = 0
+                err2_i.append(0)
+            #print p_hat_i_mc
+        sum_err2_i = sum(err2_i)
+        eyh.append(sum_err2_i**0.5)
+        eyl.append(sum_err2_i**0.5)
+    eff = ROOT.TGraphAsymmErrors(len(x), *[array('d', obj) for obj in (x,y,exl,exh,eyl,eyh)])
+    return eff, y, eyl, eyh
+
+
+def print_wald_eff(y,eyl,eyh):
+    print 'MC Sum'
+    for i,nminus1 in enumerate(nminus1s):
+        print nminus1, y[i], eyl[i], eyh[i]
+
+def table_wald(entry,nminus1, mass_range):
+    print entry.name, nminus1
+    hnum = entry.histos['NoNo']
+    hden = entry.histos[nminus1]
+    print '%20s%27s%23s%20s%16s%25s%26s' % ('cut', 'mass range','numerator', 'denominator', 'efficiency', '- 68% CL-CP +','68% CL-Wald')
+    for mbin in range(len(mass_range)):
+        if mbin == (len(mass_range)-1): break
+        mlow = mass_range[mbin]
+        mhigh = mass_range[mbin+1] 
+        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
+        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
+        pcp,lcp,hcp = clopper_pearson(num, den)
+        if num==0 and den==0:
+            eff = 0
+            errw = 0
+        else:
+            eff = num/den
+            if (eff*(1-eff))<0:
+                print "what is this"
+                print 'NM1, sample, mlow, mhigh, num, den'
+                print nminus1, entry.name, mlow, mhigh, num, den
+                eff = 1
+                errw = 0
+            else:
+                errw = (eff*(1-eff)/den)**0.5
+        if 'data' not in entry.name:
+            num = num*entry.partial_weight*lumiBCD
+            den = den*entry.partial_weight*lumiBCD
+        print '%20s%15i%15i%20f%20f%15f%15f%15f%23f'     % (nminus1, mlow, mhigh, num, den, eff, eff-lcp, hcp-eff,        errw)
+        print '%20s%15i%15i%20f%20f%15f%15f%15f%15f%16f' % (nminus1, mlow, mhigh, num, den, eff, lcp,     hcp,     eff-errw, eff+errw)
+        print ' '
+    print '---------------------------------------------'
+
+def table(entry,nminus1, mass_range):
+    print entry.name
+    hnum = entry.histos['NoNo']
+    hden = entry.histos[nminus1]
+    print '%20s%27s%23s%20s%20s%22s' % ('cut', 'mass range', 'numerator', 'denominator', 'efficiency', '68% CL')
+    for mbin in range(len(mass_range)):
+        if mbin == (len(mass_range)-1): break
+        mlow = mass_range[mbin]
+        mhigh = mass_range[mbin+1]
+        num = get_integral(hnum, mlow, mhigh, integral_only=True, include_last_bin=False)
+        den = get_integral(hden, mlow, mhigh, integral_only=True, include_last_bin=False)
+        e,l,h = clopper_pearson(num, den)
+        print '%20s%15i%15i%20f%20f%20f%15f%15f' % (nminus1, mlow, mhigh, num, den, e, l, h)
+
+# nm1entry
+class nm1entry:
+    def __init__(self, sample, is_data, lumi):
+        if type(sample) == str:
+            self.name = sample
+            self.fn = 'data/ana_nminus1_%s.root' %sample
+            #self.fn = self.make_fn(sample) if is_data else None
+            self.lumi = lumi if is_data else None
+            self.is_data = is_data
+        else:
+            self.name = sample.name
+            self.fn = self.make_fn(self.name)
+            self.partial_weight = sample.partial_weight
+            self.is_data = is_data
+        self.prepare_histos()
+            
+
+    def make_fn(self, name):
+        return 'mc/ana_nminus1_%s.root' % name
+    
+    def prepare_histos(self):
+        self.histos = {}
+        if self.fn is not None:
+            f = ROOT.TFile(self.fn)
+            for nminus1 in nminus1s + ['NoNo']:
+                self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
+
+    # This function isn't used anymore, but keep for posterity? cjsbad
+    def prepare_histos_sum(self, samples, lumi):
+        self.histos = {}
+        for nminus1 in nminus1s + ['NoNo']:
+            hs = []
+            print '%20s%20s%21s%20s%20s' % ('cut', 'sampe name', 'partial weight', 'scale(ref)','scale(lumi)')
+            for sample in samples:
+                f = ROOT.TFile(self.make_fn(sample.name))
+                h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
+                if lumi>0:
+                    # scale to luminosity for comparision of single dataset to MC
+                    h.Scale(sample.partial_weight * lumi) 
+                if lumi<0:
+                    # scale to reference cross section/Nevents for comparision of multiple datasets to MC
+                    h.Scale(sample.partial_weight * refN / refXS)  
+                hs.append(h)
+            hsum = hs[0].Clone()
+            for h in hs[1:]:
+                hsum.Add(h)
+            self.histos[nminus1] = hsum
+
+


### PR DESCRIPTION
…and move some N-1 specific functions from python/roottools.py to test/NMinus1Effs/nm1entry.py

Specifically
- Add some cmd-line options to each of the N-1 drawing scripts
- Move the nm1entry class into it's own module to be imported by all drawing scripts
- Move common dictionaries used by all plotting scripts to nm1entry.py 
- Move eff_wald() and wald_binomial_err2() which compute the efficiency and uncertainty for MC in N-1 from python/roottools.py to new file nm1entry.py
- Add flag to get_integral() in roottools.py which causes the function to go back to it's original functionality unless nm1==true and the integral is < 0, in which case it returns 0,0 (protection against negatively weighted MCs causing N-1 efficiency to go above 1 in certain cases)
