### PR TITLE
Add 2

### DIFF
--- a/plugins/HistosFromPAT.cc
+++ b/plugins/HistosFromPAT.cc
@@ -685,11 +685,11 @@ void Zprime2muHistosFromPAT::analyze(const edm::Event& event, const edm::EventSe
 			 		   	_kFactor_be = 1.064 - 0.0001674 * gM + 6.599e-08 * pow(gM,2) - 9.657e-12 * pow(gM,3);
 			 	}
 			 	
-//	    		std::cout<<"----------------------------------------------------------- GEN MASS = " <<hardInteraction->resonance->mass()<<std::endl;
-//    			std::cout<<"------------------------------------------------------------------ kFactor = "<<_kFactor<<" --- BB = "<<_kFactor_bb<<" --- BE = "<<_kFactor_be<<std::endl;
+// 	    		std::cout<<"----------------------------------------------------------- GEN MASS = " <<hardInteraction->resonance->mass()<<std::endl;
+//     			std::cout<<"------------------------------------------------------------------ kFactor = "<<_kFactor<<" --- BB = "<<_kFactor_bb<<" --- BE = "<<_kFactor_be<<std::endl;
     		} // hardInter
     		else
-//    			std::cout<<"problems"<<std::endl;
+    			std::cout<<"problems"<<std::endl;
     		} //gen_info
     	} //kFactor
         

--- a/plugins/SimpleNtupler_miniAOD.cc
+++ b/plugins/SimpleNtupler_miniAOD.cc
@@ -55,6 +55,7 @@ private:
     float dil_phi;
     float dil_dR;
     float dil_dPhi;
+    float dil_lep_pt[2];
     float cos_angle;
     float vertex_chi2;
     float cos_cs;
@@ -298,6 +299,7 @@ SimpleNtupler_miniAOD::SimpleNtupler_miniAOD(const edm::ParameterSet& cfg)
   tree->Branch("dil_phi", &t.dil_phi, "dil_phi/F");
   tree->Branch("dil_dR", &t.dil_dR, "dil_dR/F");
   tree->Branch("dil_dPhi", &t.dil_dPhi, "dil_dPhi/F");
+  tree->Branch("dil_lep_pt", t.dil_lep_pt, "dil_lep_pt[2]/F");
   tree->Branch("cos_angle", &t.cos_angle, "cos_angle/F");
   tree->Branch("vertex_chi2", &t.vertex_chi2, "vertex_chi2/F");
   tree->Branch("cos_cs", &t.cos_cs, "cos_cs/F");
@@ -715,40 +717,41 @@ void SimpleNtupler_miniAOD::analyze(const edm::Event& event, const edm::EventSet
     //
     // Store Generator Level information
     //
-    if(hardInteraction->IsValid()){
+//     if(hardInteraction->IsValid()){
+	if(hardInteraction->IsValidForRes()){
       t.gen_res_mass = hardInteraction->resonance->mass();
       t.gen_res_pt   = hardInteraction->resonance->pt();
       t.gen_res_rap  = hardInteraction->resonance->rapidity();
       t.gen_res_eta  = hardInteraction->resonance->eta();
       t.gen_res_phi  = hardInteraction->resonance->phi();
       
-      t.gen_dil_mass = hardInteraction->dilepton().mass();
-      t.gen_dil_pt   = hardInteraction->dilepton().pt();
-      t.gen_dil_rap  = hardInteraction->dilepton().Rapidity();
-      t.gen_dil_eta  = hardInteraction->dilepton().eta();
-      t.gen_dil_phi  = hardInteraction->dilepton().phi();
-      t.gen_dil_dR   = deltaR(*hardInteraction->lepMinus, *hardInteraction->lepPlus);
-      t.gen_dil_dPhi = deltaPhi(*hardInteraction->lepMinus, *hardInteraction->lepPlus);
-      
-      t.gen_lep_p[0]  = hardInteraction->lepMinus->p();
-      t.gen_lep_pt[0]  = hardInteraction->lepMinus->pt();
-      t.gen_lep_px[0]  = hardInteraction->lepMinus->px();
-      t.gen_lep_py[0]  = hardInteraction->lepMinus->py();
-      t.gen_lep_pz[0]  = hardInteraction->lepMinus->pz();
-      t.gen_lep_E[0]  = hardInteraction->lepMinus->energy();
-      t.gen_lep_eta[0] = hardInteraction->lepMinus->eta();
-      t.gen_lep_phi[0] = hardInteraction->lepMinus->phi();
-      t.gen_lep_qOverPt[0] = hardInteraction->lepMinus->charge() / hardInteraction->lepMinus->pt();
-      
-      t.gen_lep_p[1]  = hardInteraction->lepPlus->p();
-      t.gen_lep_pt[1]  = hardInteraction->lepPlus->pt();
-      t.gen_lep_px[1]  = hardInteraction->lepMinus->px();
-      t.gen_lep_py[1]  = hardInteraction->lepMinus->py();
-      t.gen_lep_pz[1]  = hardInteraction->lepMinus->pz();
-      t.gen_lep_E[1]  = hardInteraction->lepMinus->energy();
-      t.gen_lep_eta[1] = hardInteraction->lepPlus->eta();
-      t.gen_lep_phi[1] = hardInteraction->lepPlus->phi();
-      t.gen_lep_qOverPt[1] = hardInteraction->lepPlus->charge() / hardInteraction->lepPlus->pt();
+      t.gen_dil_mass = (hardInteraction->lepPlusNoIB->p4() + hardInteraction->lepMinusNoIB->p4()).mass();//hardInteraction->dilepton().mass();
+      t.gen_dil_pt   = (hardInteraction->lepPlusNoIB->p4() + hardInteraction->lepMinusNoIB->p4()).pt();
+      t.gen_dil_rap  = (hardInteraction->lepPlusNoIB->p4() + hardInteraction->lepMinusNoIB->p4()).Rapidity();
+      t.gen_dil_eta  = (hardInteraction->lepPlusNoIB->p4() + hardInteraction->lepMinusNoIB->p4()).eta();
+      t.gen_dil_phi  = (hardInteraction->lepPlusNoIB->p4() + hardInteraction->lepMinusNoIB->p4()).phi();
+      t.gen_dil_dR   = deltaR(*hardInteraction->lepMinusNoIB, *hardInteraction->lepPlusNoIB);
+      t.gen_dil_dPhi = deltaPhi(*hardInteraction->lepMinusNoIB, *hardInteraction->lepPlusNoIB);
+//       
+      t.gen_lep_p[0]  = hardInteraction->lepMinusNoIB->p();
+      t.gen_lep_pt[0]  = hardInteraction->lepMinusNoIB->pt();
+      t.gen_lep_px[0]  = hardInteraction->lepMinusNoIB->px();
+      t.gen_lep_py[0]  = hardInteraction->lepMinusNoIB->py();
+      t.gen_lep_pz[0]  = hardInteraction->lepMinusNoIB->pz();
+      t.gen_lep_E[0]  = hardInteraction->lepMinusNoIB->energy();
+      t.gen_lep_eta[0] = hardInteraction->lepMinusNoIB->eta();
+      t.gen_lep_phi[0] = hardInteraction->lepMinusNoIB->phi();
+      t.gen_lep_qOverPt[0] = hardInteraction->lepMinusNoIB->charge() / hardInteraction->lepMinusNoIB->pt();
+//       
+      t.gen_lep_p[1]  = hardInteraction->lepPlusNoIB->p();
+      t.gen_lep_pt[1]  = hardInteraction->lepPlusNoIB->pt();
+      t.gen_lep_px[1]  = hardInteraction->lepPlusNoIB->px();
+      t.gen_lep_py[1]  = hardInteraction->lepPlusNoIB->py();
+      t.gen_lep_pz[1]  = hardInteraction->lepPlusNoIB->pz();
+      t.gen_lep_E[1]  = hardInteraction->lepPlusNoIB->energy();
+      t.gen_lep_eta[1] = hardInteraction->lepPlusNoIB->eta();
+      t.gen_lep_phi[1] = hardInteraction->lepPlusNoIB->phi();
+      t.gen_lep_qOverPt[1] = hardInteraction->lepPlusNoIB->charge() / hardInteraction->lepPlusNoIB->pt();
       
       /*
        t.gen_lep_noib_pt[0]  = hardInteraction->lepMinusNoIB->pt();
@@ -794,6 +797,8 @@ void SimpleNtupler_miniAOD::analyze(const edm::Event& event, const edm::EventSet
     t.dil_phi = dil.phi();
     t.dil_dR = deltaR(*dil.daughter(0), *dil.daughter(1));
     t.dil_dPhi = deltaPhi(*dil.daughter(0), *dil.daughter(1));
+    t.dil_lep_pt[0] = dil.daughter(0)->pt();
+    t.dil_lep_pt[1] = dil.daughter(1)->pt();
 
     // Only deal with dileptons composed of e,mu for now.
     assert(dil.numberOfDaughters() == 2);

--- a/plugins/Zprime2muLeptonProducer_miniAOD.cc
+++ b/plugins/Zprime2muLeptonProducer_miniAOD.cc
@@ -13,7 +13,8 @@
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/View.h"
-
+#include "SUSYBSMAnalysis/Zprime2muAnalysis/src/GeneralizedEndpoint.h"
+#include "TLorentzVector.h"
 
 
 class Zprime2muLeptonProducer_miniAOD : public edm::EDProducer {
@@ -161,17 +162,36 @@ pat::Muon* Zprime2muLeptonProducer_miniAOD::cloneAndSwitchMuonTrack(const pat::M
   
   reco::Particle::Point vtx(newTrack->vx(), newTrack->vy(), newTrack->vz());
   reco::Particle::LorentzVector p4;
-  
-  const double p = newTrack->p();
-  
-  p4.SetXYZT(newTrack->px(), newTrack->py(), newTrack->pz(), sqrt(p*p + mass*mass));  
-  
-  mu->setCharge(newTrack->charge());
-  
-  mu->setP4(p4);
-  
-  mu->setVertex(vtx);
 
+  //////////   Comment following lines to apply pt bias correction /////
+   const double p = newTrack->p();  
+   p4.SetXYZT(newTrack->px(), newTrack->py(), newTrack->pz(), sqrt(p*p + mass*mass));  
+  //////////   Comment previous lines to apply pt bias correction ----->  Uncomment following lines /////
+
+
+  
+	///////// uncomment following lines to apply pt bias correction -----> comment previous lines /////////
+//  float phi = newTrack->phi()*TMath::RadToDeg();
+
+//  float mupt = GeneralizedEndpoint().GeneralizedEndpointPt(newTrack->pt(),newTrack->charge(),newTrack->eta(),phi,-1,1); //for DATA
+//  float mupt = GeneralizedEndpoint().GeneralizedEndpointPt(newTrack->pt(),newTrack->charge(),newTrack->eta(),phi,0,1);  // for MC
+
+
+//	float px = mupt*TMath::Cos(newTrack->phi());
+//	float py = mupt*TMath::Sin(newTrack->phi());
+//	float pz = mupt*TMath::SinH(newTrack->eta());
+//	float p = mupt*TMath::CosH(newTrack->eta());
+//	p4.SetXYZT(px, py, pz, sqrt(p*p + mass*mass));
+
+// 	std::cout<<"my definition = "<<mupt<<std::endl;
+	/////// uncomment previous lines to apply pt bias correction /////////
+
+
+  mu->setP4(p4);  
+
+  mu->setCharge(newTrack->charge());
+
+  mu->setVertex(vtx);
 
   mu->addUserInt("trackUsedForMomentum", type);
   

--- a/python/DileptonPreselector_cfi.py
+++ b/python/DileptonPreselector_cfi.py
@@ -3,6 +3,6 @@ import FWCore.ParameterSet.Config as cms
 dileptonPreseletor = cms.EDFilter("DileptonPreselector",
 	muons = cms.InputTag("slimmedMuons"),
 	nMuons = cms.double(2),
-	ptCut = cms.double(20),	
+	ptCut = cms.double(40),	
 
 )

--- a/python/HistosFromPAT_cfi.py
+++ b/python/HistosFromPAT_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from SUSYBSMAnalysis.Zprime2muAnalysis.HardInteraction_cff import hardInteraction,hardInteraction_MiniAOD
 
 HistosFromPAT = cms.EDAnalyzer('Zprime2muHistosFromPAT',
                                lepton_src = cms.InputTag('leptons', 'muons'),
@@ -8,6 +9,8 @@ HistosFromPAT = cms.EDAnalyzer('Zprime2muHistosFromPAT',
                                vertex_src = cms.InputTag('offlinePrimaryVertices'),
                                use_bs_and_pv = cms.bool(True),
                                useMadgraphWeight = cms.bool(True),
+                               usekFactor = cms.bool(False),
+                               hardInteraction = hardInteraction,
                                )
 
 HistosFromPAT_MiniAOD = cms.EDAnalyzer('Zprime2muHistosFromPAT',
@@ -18,4 +21,6 @@ HistosFromPAT_MiniAOD = cms.EDAnalyzer('Zprime2muHistosFromPAT',
                                vertex_src = cms.InputTag('offlineSlimmedPrimaryVertices'),
                                use_bs_and_pv = cms.bool(True),
                                useMadgraphWeight = cms.bool(True),
+                               usekFactor = cms.bool(False),
+                               hardInteraction = hardInteraction_MiniAOD,
 )

--- a/python/MCSamples.py
+++ b/python/MCSamples.py
@@ -54,48 +54,57 @@ class tupleonlysample(sample):
 # Single-top cross sections are from https://twiki.cern.ch/twiki/bin/viewauth/CMS/SingleTopSigma
 # K factor for Drell-Yan samples is the ratio of the NNLO to POWHEG cross sections for M > 20 GeV bin, 1915/1871=1.024
 samples = [
+    sample('dy50to120',   'DY50to120', '/ZToMuMu_NNPDF30_13TeV-powheg_M_50_120/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 2977600, 209 , 1., 1975,   k_factor=1.),#NLO xs and k-factor applied to reach NLO
+    sample('dy120to200',  'DY120to200', '/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 210, 1., 19.32, k_factor=1.),#mcm 19.32
+    sample('dy200to400',  'DY200to400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 211, 1., 2.731, k_factor=1.),#mcm 2.731
+    sample('dy400to800',  'DY400to800', '/ZToMuMu_NNPDF30_13TeV-powheg_M_400_800/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 98400, 212, 1., 0.241, k_factor=1.),
+    sample('dy800to1400', 'DY800to1400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_800_1400/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 72, 1., 0.01678, k_factor=1.),
+    sample('dy1400to2300','DY1400to2300', '/ZToMuMu_NNPDF30_13TeV-powheg_M_1400_2300/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 70 , 1., 0.00139,    k_factor=1.),
+    sample('dy2300to3500','DY2300to3500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_2300_3500/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 70 , 1., 0.00008948,    k_factor=1.),
+    sample('dy3500to4500','DY3500to4500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 70 , 1., 0.0000041,    k_factor=1.),
+    sample('dy4500to6000','DY4500to6000', '/ZToMuMu_NNPDF30_13TeV-powheg_M_4500_6000/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 100000, 70 , 1., 4.56E-7,    k_factor=1.),    
+
     
-    sample('dy50to120',   'DY50to120', '/ZToMuMu_NNPDF30_13TeV-powheg_M_50_120/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 2976600, 209 , 1., 1975,   k_factor=1.006),#NLO xs and k-factor applied to reach NLO
-    sample('dy120to200',  'DY120to200', '/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 210, 1., 19.32, k_factor=1.006),#mcm 19.32
-    sample('dy200to400',  'DY200to400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 211, 1., 2.731, k_factor=1.006),#mcm 2.731
-    sample('dy400to800',  'DY400to800', '/ZToMuMu_NNPDF30_13TeV-powheg_M_400_800/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 99000, 212, 1., 0.241, k_factor=1.006),
-    sample('dy800to1400', 'DY800to1400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_800_1400/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 72, 1., 0.01678, k_factor=1.006),
-    sample('dy1400to2300','DY1400to2300', '/ZToMuMu_NNPDF30_13TeV-powheg_M_1400_2300/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 70 , 1., 0.00139,    k_factor=1.006),
-    sample('dy2300to3500','DY2300to3500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_2300_3500/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 70 , 1., 0.00008948,    k_factor=1.006),
-    sample('dy3500to4500','DY3500to4500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 99000, 70 , 1., 0.0000041,    k_factor=1.006),
-    sample('dy4500to6000','DY4500to6000', '/ZToMuMu_NNPDF30_13TeV-powheg_M_4500_6000/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 100000, 70 , 1., 4.56E-7,    k_factor=1.006),
-
-
-    sample('WZ', 'WZ', '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 1000000, 98, 1., 47.13, k_factor=1.),#NLO from MCFM
-    sample('ZZ',   'ZZ', '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 989312, 94, 1.,16.523, k_factor=1.),#NLO from MCFM
-##   WWincl   ###
-    sample('WWinclusive', 'WWinclusive','/WWTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 1996600, 208, 1., 12.178, k_factor=1.),#already NNLO xs
-    sample('WW200to600', 'WW200to600','/WWTo2L2Nu_Mll_200To600_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 200000, 208, 1., 1.385, k_factor=1.),#already NNLO xs
-    sample('WW600to1200', 'WW600to1200','/WWTo2L2Nu_Mll_600To1200_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 200000, 208, 1., 0.0566, k_factor=1.),#already NNLO xs
-    sample('WW1200to2500', 'WW1200to2500','/WWTo2L2Nu_Mll_1200To2500_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 200000, 208, 1., 0.0035, k_factor=1.),#already NNLO xs
-    sample('WW2500', 'WW2500','/WWTo2L2Nu_Mll_2500ToInf_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 38969, 208, 1., 0.00005, k_factor=1.),#already NNLO xs
-
-
-###   dyIncl   ###
-    sample('dyInclusive50',          'DYInclusive50', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 28696958, 209 , 1., 6025.2,    k_factor=1., is_madgraph=True),  #(I will update the number of events)
-          sample('Wjets', 'Wjets', '/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',28210360,52,1.,61526.7,k_factor=1),#already NNLO xs
-          sample('ttbar_lep',     'ttbar_lep', '/TTTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0_ext1-v1/MINIAODSIM', 104607105, 4 , 1., 87.31, k_factor=1.),
-          sample('Wantitop', 'WantiTop', '/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',985000,63 , 1., 35.6, k_factor=1.),#already NNLO xs          
-          sample('tW',     'tW', '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v2/MINIAODSIM',998400,66 , 1., 35.6, k_factor=1.),#already NNLO xs
-
-
-    sample('qcd80to120', 'QCD80to120', '/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',699511,43,1.,2762530,k_factor=1),
-    sample('qcd120to170', 'QCD120to170', '/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',698555,43,1.,471100,k_factor=1),
-    sample('qcd170to300', 'QCD170to300', '/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',699973,43,1.,117276,k_factor=1),
-    sample('qcd300to470', 'QCD300to470', '/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM', 2482816,43,1.,7823,k_factor=1),
-    sample('qcd470to600', 'QCD470to600', '/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',1998648,43,1.,648.2,k_factor=1),
-    sample('qcd600to800', 'QCD600to800', '/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',1385860,43,1.,186.9,k_factor=1),
-    sample('qcd800to1000', 'QCD800to1000', '/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',399968,43,10,32.293,k_factor=1),
-    sample('qcd1000to1400', 'QCD1000to1400', '/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',299967,43,1.,9.4183,k_factor=1),
-    sample('qcd1400to1800', 'QCD1400to1800', '/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',39874,43,1.,0.84265,k_factor=1),
-    sample('qcd1800to2400', 'QCD1800to2400', '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',39975,43,1.,0.114943,k_factor=1),
-    sample('qcd2400to3200', 'QCD2400to3200', '/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',39990,43,1.,0.00682981,k_factor=1),
-    sample('qcd3200', 'QCD3200', '/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM',39988,43,1.,0.000165445,k_factor=1),
+     sample('WZ', 'WZ', '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 1000000, 98, 1., 47.13, k_factor=1.),#NLO from MCFM
+     sample('WZ_ext', 'WZ_ext', '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM', 2995828, 98, 1., 47.13, k_factor=1.),
+ 
+     sample('ZZ',   'ZZ', '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 990064, 94, 1.,16.523, k_factor=1.),#NLO from MCFM
+ 	sample('ZZ_ext',   'ZZ_ext', '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM', 998034, 94, 1.,16.523, k_factor=1.),
+ 
+ 	sample('WWinclusive', 'WWinclusive', '/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 1999000, 208, 1., 12.178, k_factor=1.),#already NNLO xs
+ 	sample('WW200to600', 'WW200to600', '/WWTo2L2Nu_Mll_200To600_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 200000, 208, 1., 1.385, k_factor=1.),#already NNLO xs
+     sample('WW600to1200', 'WW600to1200', '/WWTo2L2Nu_Mll_600To1200_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 200000, 208, 1., 0.0566, k_factor=1.),#already NNLO xs
+     sample('WW1200to2500', 'WW1200to2500', '/WWTo2L2Nu_Mll_1200To2500_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 200000, 208, 1., 0.003557, k_factor=1.),#already NNLO xs
+     sample('WW2500', 'WW2500','/WWTo2L2Nu_Mll_2500ToInf_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 38969, 208, 1., 0.00005395, k_factor=1.),#already NNLO xs
+ 
+ 	sample('Wjets', 'Wjets', '/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',29705748,52,1.,61526.7,k_factor=1),#already NNLO xs
+ 
+# 	########sample('ttbar_lep',     'ttbar_lep', '/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 79092400, 4 , 1., 87.31, k_factor=1.),
+ 	sample('ttbar_lep50to500',     'ttbar_lep50to500', '/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 79092400, 4 , 1., 87.31, k_factor=1.),
+ 	sample('ttbar_lep_500to800',     'ttbar_lep_500to800', '/TTToLL_MLL_500To800_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 200000, 4 , 1., 0.32611, k_factor=1.),
+ 	sample('ttbar_lep_800to1200',     'ttbar_lep_800to1200', '/TTToLL_MLL_800To1200_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 199800, 4 , 1., 0.03265, k_factor=1.),
+ 	sample('ttbar_lep_1200to1800',     'ttbar_lep_1200to1800', '/TTToLL_MLL_1200To1800_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 200000, 4 , 1., 0.00305, k_factor=1.),
+ 	sample('ttbar_lep1800toInf',     'ttbar_lep1800toInf', '/TTToLL_MLL_1800ToInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 40829, 4 , 1., 0.00017, k_factor=1.),
+ 	
+ 	sample('Wantitop', 'WantiTop', '/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',6933094,63 , 1., 35.6, k_factor=1.),#already NNLO xs          
+     sample('tW',     'tW', '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM',6952830,66 , 1., 35.6, k_factor=1.),#already NNLO xs
+ 
+# ###    sample('qcd50to80', 'QCD50to80', '/QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 9954370,43,1.,1,k_factor=1),
+ 	sample('qcd80to120', 'QCD80to120', '/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',6986740,43,1.,2762530,k_factor=1),
+     sample('qcd120to170', 'QCD120to170', '/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',6708572,43,1.,471100,k_factor=1),
+    	sample('qcd170to300', 'QCD170to300', '/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',6958708,43,1.,117276,k_factor=1),
+     sample('qcd300to470', 'QCD300to470', '/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 4150588,43,1.,7823,k_factor=1),
+    	sample('qcd470to600', 'QCD470to600', '/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',3959986,43,1.,648.2,k_factor=1),
+     sample('qcd600to800', 'QCD600to800', '/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',3896412,43,1.,186.9,k_factor=1),
+ 	sample('qcd800to1000', 'QCD800to1000', '/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',3992112,43,10,32.293,k_factor=1),
+     sample('qcd1000to1400', 'QCD1000to1400', '/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',2999069,43,1.,9.4183,k_factor=1),
+     sample('qcd1400to1800', 'QCD1400to1800', '/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',396409,43,1.,0.84265,k_factor=1),
+     sample('qcd1800to2400', 'QCD1800to2400', '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',397660,43,1.,0.114943,k_factor=1),
+     sample('qcd2400to3200', 'QCD2400to3200', '/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM',399226,43,1.,0.00682981,k_factor=1),
+     sample('qcd3200', 'QCD3200', '/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM',391735,43,1.,0.000165445,k_factor=1),
+ 
+# ### 	N_EVENT scaled by: -N_EVENT * n_neg/n + n * n_pos/n (N_EVENT from report = 28968252; n from weight = 9112991 n_neg = 1507200 (0.1654); n_pos = 7605790 (0.8346); )
+ 	sample('dyInclusive50', 'DYInclusive50', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM', 19385554, 209 , 1., 5765.4,    k_factor=1., is_madgraph=True),  
 
     ]
 

--- a/python/METFilterMiniAOD_cfi.py
+++ b/python/METFilterMiniAOD_cfi.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 defaultSelector = cms.EDFilter("METFilterMiniAOD",
-#                               src = cms.InputTag("TriggerResults","","PAT"),
-                               src = cms.InputTag("TriggerResults","","RECO"),
+                               src = cms.InputTag("TriggerResults","","PAT"),	# to submit MC
+#                                src = cms.InputTag("TriggerResults","","RECO"), # to submit data
                                flag = cms.string("Flag_globalTightHalo2016Filter"),
                                applyfilter = cms.untracked.bool(True),
                                debugOn = cms.untracked.bool(False),

--- a/python/OurSelection2016_cff.py
+++ b/python/OurSelection2016_cff.py
@@ -41,6 +41,7 @@ from SUSYBSMAnalysis.Zprime2muAnalysis.hltTriggerMatch_cfi import trigger_match,
 loose_cut = 'isGlobalMuon && ' \
             'isTrackerMuon && ' \
             'pt > %s && ' \
+            'abs(eta) < 2.4 && ' \
             'abs(dB) < 0.2 && ' \
             'isolationR03.sumPt / innerTrack.pt < 0.10 && ' \
             'globalTrack.hitPattern.trackerLayersWithMeasurement > 5 && ' \

--- a/python/OurSelectionDec2012_cff.py
+++ b/python/OurSelectionDec2012_cff.py
@@ -41,6 +41,7 @@ from SUSYBSMAnalysis.Zprime2muAnalysis.hltTriggerMatch_cfi import trigger_match,
 loose_cut = 'isGlobalMuon && ' \
             'isTrackerMuon && ' \
             'pt > %s && ' \
+            'abs(eta) < 2.4 && ' \
             'abs(dB) < 0.2 && ' \
             'isolationR03.sumPt / innerTrack.pt < 0.10 && ' \
             'globalTrack.hitPattern.trackerLayersWithMeasurement > 5 && ' \

--- a/python/goodlumis.py
+++ b/python/goodlumis.py
@@ -6,10 +6,10 @@ def for_cmssw(ll):
 
 # These run numbers guide the combination of the prompt and DCS-only
 # JSONs.
-first_run = 246908 #first DCS run or first analyzed run
-last_rereco_run = 198523
-last_prompt_run = 256869
-last_run = 256869 #last DCS run or last analyzed run
+first_run = 271036 #first DCS run or first analyzed run
+last_rereco_run = 284044
+last_prompt_run = 284044
+last_run = 284044 #last DCS run or last analyzed run
 
 # Sometimes the same run-range json gets made in other versions.
 prompt_version = ''
@@ -64,8 +64,10 @@ DCSOnlyForNewRuns_ll.removeRuns(runs_to_remove_from_dcsonly)
 #Prompt 2015C
 #Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_MuonPhys.txt
 #Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_MuonPhys.txt
-Prompt_ll          = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_%i-%i_13TeV_PromptReco_Collisions15_25ns_JSON%s.txt' % (first_run, last_prompt_run, prompt_version))
-PromptMuonsOnly_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_%i-%i_13TeV_PromptReco_Collisions15_25ns_JSON_MuonPhys%s.txt' % (first_run, last_prompt_run, prompt_version))
+
+Prompt_ll          = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_%i-%i_13TeV_23Sep2016ReReco_Collisions16_JSON%s.txt' % (first_run, last_prompt_run, prompt_version))
+PromptMuonsOnly_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_%i-%i_13TeV_23Sep2016ReReco_Collisions16_JSON_MuonPhys%s.txt' % (first_run, last_prompt_run, prompt_version))
+
 #PromptMuonsOnly_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/Cert_%i-%i_13TeV_PromptReco_Collisions15_50ns_JSON_MuonPhys%s_v2.txt' % (first_run, last_prompt_run, prompt_version))
 #Prompt_ll          = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions12/8TeV/Prompt/Cert_%i-%i_8TeV_PromptReco_Collisions12_JSON%s.txt'          % (first_run, last_prompt_run, prompt_version))
 #PromptMuonsOnly_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions12/8TeV/Prompt/Cert_%i-%i_8TeV_PromptReco_Collisions12_JSON_MuonPhys%s.txt' % (first_run, last_prompt_run, prompt_version))
@@ -96,8 +98,8 @@ def combine(prompt_ll, rereco1_ll, rereco2_ll, rereco3_ll, dcsonly_ll=None):
 # Combine all lists
 #Run2012_ll          = combine(Prompt_ll,          Jul13_ll,          Aug06_ll,          Aug24_ll)
 #Run2012MuonsOnly_ll = combine(PromptMuonsOnly_ll, Jul13MuonsOnly_ll, Aug06MuonsOnly_ll, Aug24MuonsOnly_ll)
-Run2015_ll          = Prompt_ll
-Run2015MuonsOnly_ll = PromptMuonsOnly_ll
+Run2016_ll          = Prompt_ll
+Run2016MuonsOnly_ll = PromptMuonsOnly_ll
 ## for x in NoL1TMuonsOnly_ll:
 ##     Run2012MuonsOnly_ll = Run2012MuonsOnly_ll | x
 #Run2012_ll          = Jan22_ll
@@ -121,7 +123,7 @@ Run2012PlusDCSOnlyMuonsOnly_ll = Jan22MuonsOnly_ll | dcsonly_ll
 # Run2012_ll = Dec11_ll
 
 #all_ll_names = ['DCSOnly', 'DCSOnlyForNewRuns', 'Jan22', 'Jan22MuonsOnly', 'Run2015', 'Run2015MuonsOnly', 'Run2012PlusDCSOnly', 'Run2012PlusDCSOnlyMuonsOnly']
-all_ll_names = ['DCSOnly', 'Run2015', 'Run2015MuonsOnly']
+all_ll_names = ['DCSOnly', 'Run2016', 'Run2016MuonsOnly']
 
 #print 'DCSOnly', DCSOnly_ll
 #print 'Run2015', Run2015_ll
@@ -137,8 +139,8 @@ for base_name, ll in all_lls():
 if __name__ == '__main__':
     import sys
     if 'write' in sys.argv:
-        Run2015MuonsOnly_ll.writeJSON('Run2015MuonsOnly.json')
-        Run2015_ll.writeJSON('Run2015.json')
+        Run2016MuonsOnly_ll.writeJSON('Run2016MuonsOnly.json')
+        Run2016_ll.writeJSON('Run2016.json')
     elif 'write_all' in sys.argv:
         for base_name, ll in all_lls():
             ll.writeJSON('zp2mu_goodlumis_%s.json' % base_name)

--- a/src/GeneralizedEndpoint.cc
+++ b/src/GeneralizedEndpoint.cc
@@ -1,0 +1,129 @@
+#include "GeneralizedEndpoint.h"
+#include <iostream>
+#include "TRandom.h"
+#include <math.h>
+using std::cout;
+using std::cerr;
+using std::endl;
+
+GeneralizedEndpoint::GeneralizedEndpoint(){
+  //Corrections from 2D matrix in MuonPOG presentation in c/TeV.
+  //[-2.4, -2.1]
+  _Correction[0][0] = -0.388122; _CorrectionError[0][0] = 0.045881; //-180,-60
+  _Correction[0][1] =  0.376061; _CorrectionError[0][1] = 0.090062; //-60,60
+  _Correction[0][2] =  -0.153950; _CorrectionError[0][2] = 0.063053; //60,180
+  //[-2.1, -1.2]                                                                                           
+  _Correction[1][0] =  -0.039346; _CorrectionError[1][0] = 0.031655;
+  _Correction[1][1] =  0.041069;  _CorrectionError[1][1] = 0.030070;
+  _Correction[1][2] =  -0.113320; _CorrectionError[1][2] = 0.028683;
+  //[-1.2, 0.]
+  _Correction[2][0] =  0.0;      _CorrectionError[2][0] = 0.03;
+  _Correction[2][1] =  0.0;      _CorrectionError[2][1] = 0.03;
+  _Correction[2][2] =  0.0;      _CorrectionError[2][2] = 0.03;
+  //[-0., 1.2]
+  _Correction[3][0] =  0.0;      _CorrectionError[3][0] = 0.03;
+  _Correction[3][1] =  0.0;      _CorrectionError[3][1] = 0.03;
+  _Correction[3][2] =  0.0;      _CorrectionError[3][2] = 0.03;
+  //[1.2, 2.1]
+  _Correction[4][0] =  0.005114; _CorrectionError[4][0] = 0.033115;
+  _Correction[4][1] =  0.035573; _CorrectionError[4][1] = 0.038574;
+  _Correction[4][2] =  0.070002; _CorrectionError[4][2] = 0.035002;
+  //[2.1, 2.4]
+  _Correction[5][0] =  -0.235470; _CorrectionError[5][0] = 0.077534;
+  _Correction[5][1] =  -0.122719; _CorrectionError[5][1] = 0.061283;
+  _Correction[5][2] =  0.091502;  _CorrectionError[5][2] = 0.074502;
+
+
+};
+
+GeneralizedEndpoint::~GeneralizedEndpoint()
+{
+};
+
+float GeneralizedEndpoint::GeneralizedEndpointPt(float MuonPt, int MuonCharge, float MuonEta, float MuonPhi, int Mode, int verbose){
+
+  //Check the input format.
+  if (fabs(MuonEta)>2.4) {
+    cerr<<"ERROR: MuonEta = "<< MuonEta << ", outisde valide range = [-2.4,2.4] "<<endl;
+    return 0;
+  }
+  if (fabs(MuonPhi)>180) {
+    cerr<<"ERROR: MuonPhi = "<< MuonPhi << ", outisde valide range = [-180,180] "<<endl;
+    return 0;
+  }
+  if (MuonCharge != 1 && MuonCharge != -1) {
+    cerr<<"ERROR: Invalide Muon Charge = "<< MuonCharge << endl;
+    return 0;
+  }
+  if (Mode != 0 && Mode != 1 && Mode != 2 && Mode != -1 && Mode != -2 && Mode != -3) {
+    cerr<<"ERROR: Invalide Mode = "<< Mode << endl;
+    cerr<<"\t: Valid modes: 0 = Nominal, 1 = SystematicUp and 2 = SystematicDown "<< endl;
+    cerr<<"\t: Experimental mode: -1 = Nominal for Data, -2 = SystematicUp and -3 = SystematicDown "<< endl;
+    return 0;
+  }
+
+  // Eta Binning
+  unsigned int etaBINS = 6;
+  unsigned int kEtaBin = etaBINS;
+  double EtaBin[etaBINS+1];
+  EtaBin[0]=-2.4; EtaBin[1]=-2.1; EtaBin[2]=-1.2; EtaBin[3]=0.;
+  EtaBin[4]=1.2; EtaBin[5]=2.1; EtaBin[6]=2.4;  
+
+  // Phi Binning.
+  unsigned int phiBINS =3;
+  unsigned int kPhiBin = phiBINS;
+  double PhiBin[phiBINS+1];
+  PhiBin[0]=-180.; PhiBin[1]=-60.; PhiBin[2]=60.; PhiBin[3]=180.;
+  
+
+  for (unsigned int kbin=0; kbin<=etaBINS; ++kbin) {
+    if (MuonEta<EtaBin[kbin+1]) {
+      kEtaBin = kbin;
+      break;
+    }
+  }
+
+  for (unsigned int kbin=0; kbin<=phiBINS; ++kbin) {
+    if (MuonPhi<PhiBin[kbin+1]) {
+      kPhiBin = kbin;
+      break;
+    }
+  }
+
+  float KappaBias=_Correction[kEtaBin][kPhiBin];
+  float KappaBiasError=_CorrectionError[kEtaBin][kPhiBin];
+  
+  float rnd = KappaBias+99*KappaBiasError;
+  while (abs(KappaBias-rnd) > KappaBiasError)
+    rnd = gRandom->Gaus(KappaBias,KappaBiasError);
+
+  KappaBias = rnd;
+  // if ((KappaBias-KappaBiasError)/KappaBias > 0.70) return MuonPt;
+  //  if (abs(KappaBiasError/KappaBias) > 0.70) return MuonPt; // ignore the bias if the error on the estimation is too big... 
+  
+
+  if (Mode==1) KappaBias = KappaBias+KappaBiasError; //Take bias + UpSystematic.
+  if (Mode==2) KappaBias = KappaBias-KappaBiasError; //Takes bias - DownSystematic.
+
+  /// Experimental ///
+  if (Mode==-1) KappaBias = -1*KappaBias; //Reverse the sign to use it with data as first approximation. (this option has some non-trivial assumptions).
+  if (Mode==-2) KappaBias = -1*(KappaBias+KappaBiasError); //Reverse the sign to use it with data as first approximation. (this option has some non-trivial assumptions).
+  if (Mode==-3) KappaBias = -1*(KappaBias-KappaBiasError); //Reverse the sign to use it with data as first approximation. (this option has some non-trivial assumptions).
+  //////
+
+  if (verbose ==1) printf("eta bin %i, phi bin %i Correction %f +- %f pt %f\n", kEtaBin, kPhiBin, KappaBias, KappaBiasError,MuonPt);
+
+  MuonPt = MuonPt/1000.; //GeV to TeV.
+  MuonPt = MuonCharge*fabs(MuonPt); //Signed Pt.
+  MuonPt = 1/MuonPt; //Convert to Curvature.
+  MuonPt = MuonPt + KappaBias; //Apply the bias.
+  if (fabs(MuonPt) < 0.14 && verbose ==1)  printf("WARNING: Very small curvature after correction!(is this expected?) eta = %.2f, phi = %.2f \n", MuonEta, MuonPhi);
+  if (fabs(MuonPt) < 0.14) MuonPt = KappaBiasError; //To avoid a division by set the curvature to its error if after the correction the pt is larger than 7 TeV.
+  MuonPt = 1/MuonPt;//Return to Pt.
+  MuonPt = fabs(MuonPt);//returns unsigned Pt, any possible sign flip due to the curvature is absorbed here.
+  MuonPt = MuonPt*1000.;//Return to Pt in GeV.
+
+  if (verbose ==1) printf("NEW pt %f\n", MuonPt);
+
+  return MuonPt;
+};

--- a/src/GeneralizedEndpoint.h
+++ b/src/GeneralizedEndpoint.h
@@ -1,0 +1,18 @@
+// * GeneralizedEndpoint.h
+#include <iostream>
+#include <map>
+
+#ifndef GENERALIZEDENDPOINT_H_
+#define GENERALIZEDENDPOINT_H_
+
+class GeneralizedEndpoint {
+ public:
+   GeneralizedEndpoint();
+   virtual ~GeneralizedEndpoint();
+   float GeneralizedEndpointPt(float MuonPt, int MuonCharge, float MuonEta, float MuonPhi, int Mode, int verbose=0);
+ private:
+   std::map<int,std::map<int,float> > _Correction;
+   std::map<int,std::map<int,float> > _CorrectionError;   
+
+ };
+#endif /* GENERALIZEDENDPOINT_H_ */

--- a/test/DataMCSpectraComparison/histos.py
+++ b/test/DataMCSpectraComparison/histos.py
@@ -10,20 +10,26 @@ from SUSYBSMAnalysis.Zprime2muAnalysis.Zprime2muAnalysis_cfg import process
 from SUSYBSMAnalysis.Zprime2muAnalysis.Zprime2muAnalysis_cff import goodDataFiltersMiniAOD
 
 process.source.fileNames =[#'file:./pat.root'
+'/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/2810A5DC-03C8-E611-B20C-001E67504B25.root',
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/824C363B-0AC8-E611-B4A5-20CF3027A580.root',
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_50_120/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/60000/243D09B4-90D1-E611-B0FA-001E674DA347.root',
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/06BD3929-EDC7-E611-8EC3-02163E019C96.root',
 
-            '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/162AD1DB-1E98-E611-9893-008CFA56D58C.root',
+
+
+#            '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/162AD1DB-1E98-E611-9893-008CFA56D58C.root',
 #            '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/1A1F07FF-2698-E611-915C-0242AC130004.root',
                            
-#                           '/store/mc/RunIISpring16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/90000/18C80393-613A-E611-86DF-0090FAA573E0.root',
-#                            '/store/mc/RunIISpring16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/50000/000FF6AC-9F2A-E611-A063-0CC47A4C8EB0.root',
 
 			   
 			   ]
-process.maxEvents.input =-1
-process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v4' #re_reco data
-#process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_miniAODv2_v1' # for MC
+process.maxEvents.input = -1
+# process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6' #RunB to RunG   #change line 461
+# process.GlobalTag.globaltag = '80X_dataRun2_Prompt_v14' #RunH  #change line 461
+
+process.GlobalTag.globaltag = '80X_mcRun2_asymptotic_2016_miniAODv2_v1' # for MC
 #process.options.wantSummary = cms.untracked.bool(True)# false di default
-process.MessageLogger.cerr.FwkReport.reportEvery = 1 # default 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000 # default 1000
 
 from SUSYBSMAnalysis.Zprime2muAnalysis.hltTriggerMatch_cfi import trigger_match, prescaled_trigger_match, trigger_paths, prescaled_trigger_paths, overall_prescale, offline_pt_threshold, prescaled_offline_pt_threshold
 
@@ -46,6 +52,7 @@ if miniAOD:
 
 	from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT_MiniAOD as HistosFromPAT
 	HistosFromPAT.leptonsFromDileptons = True
+	HistosFromPAT.usekFactor = False #### Set TRUE to use K Factor on DY. If used, the k factor will be applied to ALL samples submitted. #####
 
 else:
 	from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT
@@ -60,6 +67,9 @@ else:
 import SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionNew_cff as OurSelectionNew
 import SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff as OurSelectionDec2012
 import SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff as OurSelection2016
+
+
+
 
 
 
@@ -141,8 +151,8 @@ for cut_name, Selection in cuts.iteritems():
 		    leptons.electron_muon_veto_dR = 0.1
 
     # Keep using old TuneP for past selections
-    if 'Dec2012' not in Selection.__file__:
-        leptons.muon_track_for_momentum = cms.string('TuneP')
+#     if 'Dec2012' not in Selection.__file__:
+#         leptons.muon_track_for_momentum = cms.string('TunePNew')
     setattr(process, leptons_name, leptons)
     path_list.append(leptons)
 
@@ -206,12 +216,55 @@ for cut_name, Selection in cuts.iteritems():
        #define the list of MC samples to be read here. be careful that if WWinclusive or tautau sample are not commented it will apply the filters when running locally.
 
     samples = [
-               ('dy200to400','/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM'),
-	       #('dy200to400','/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/rradogna-datamc_dy200to400-20330eea4b39a6d27baf680b4cd56b47/USER'),
-               #  ('dy200to400','/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM'),
-	       # ('dy50to120','/ZToMuMu_NNPDF30_13TeV-powheg_M_50_120/RunIISpring16MiniAODv2-PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM'),
-	        # ('WWinclusive','/WWTo2L2Nu_13TeV-powheg/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM'),
-		#('tautau', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM'),
+	    ('dy50to120', '/ZToMuMu_NNPDF30_13TeV-powheg_M_50_120/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+    	('dy120to200', '/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+	    ('dy200to400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_200_400/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+    	('dy400to800', '/ZToMuMu_NNPDF30_13TeV-powheg_M_400_800/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+	    ('dy800to1400', '/ZToMuMu_NNPDF30_13TeV-powheg_M_800_1400/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+    	('dy1400to2300', '/ZToMuMu_NNPDF30_13TeV-powheg_M_1400_2300/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+	    ('dy2300to3500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_2300_3500/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+    	('dy3500to4500', '/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+	    ('dy4500to6000', '/ZToMuMu_NNPDF30_13TeV-powheg_M_4500_6000/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+
+#     	('WZ', '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('WZ_ext', '/WZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM'),
+#     	
+# 	    ('ZZ', '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('ZZ_ext', '/ZZ_TuneCUETP8M1_13TeV-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM'),
+# 
+#     	('WWinclusive', '/WWTo2L2Nu_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('WW200to600', '/WWTo2L2Nu_Mll_200To600_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('WW600to1200', '/WWTo2L2Nu_Mll_600To1200_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('WW1200to2500', '/WWTo2L2Nu_Mll_1200To2500_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('WW2500', '/WWTo2L2Nu_Mll_2500ToInf_13TeV-powheg/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 
+#     	('dyInclusive50', '/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISummer16MiniAODv2-PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 
+# 	    ('Wjets', '/WJetsToLNu_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 
+# ####     	('ttbar_lep', '/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('ttbar_lep50to500', '/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 		('ttbar_lep_500to800', '/TTToLL_MLL_500To800_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 		('ttbar_lep_800to1200', '/TTToLL_MLL_800To1200_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 		('ttbar_lep_1200to1800', '/TTToLL_MLL_1200To1800_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 		('ttbar_lep1800toInf', '/TTToLL_MLL_1800ToInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 
+# 	    ('Wantitop', '/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM'),
+#     	('tW', '/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM'),
+# 
+# ###	    ('qcd50to80', '/QCD_Pt_50to80_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd80to120', '/QCD_Pt_80to120_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd120to170', '/QCD_Pt_120to170_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd170to300', '/QCD_Pt_170to300_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd300to470', '/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd470to600', '/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd600to800', '/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd800to1000', '/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd1000to1400', '/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd1400to1800', '/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd1800to2400', '/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+#     	('qcd2400to3200', '/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+# 	    ('qcd3200', '/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM'),
 		
         ]
 
@@ -226,13 +279,30 @@ for cut_name, Selection in cuts.iteritems():
 
 
     for name, ana_dataset in samples:
+    
+	if 'ttbar_lep50to500' in name:
+			if miniAOD:
+				process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
+				process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
+							       src = cms.InputTag('prunedGenParticles'),
+							       min_mass = cms.double(50),
+							       max_mass = cms.double(500), 
+							       )
+			else:
+				process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
+							       src = cms.InputTag('prunedMCLeptons'),
+							       min_mass = cms.double(50),
+							       max_mass = cms.double(500), 
+							       )   
+			pobj = process.DYGenMassFilter * pobj
+		
 	if 'WWinclusive' in name:
 		if miniAOD:
 			process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
 			process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
 							       src = cms.InputTag('prunedGenParticles'),
 							       min_mass = cms.double(50),
-							       max_mass = cms.double(200),
+							       max_mass = cms.double(200), 
 							       )
 		else:
 			process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
@@ -242,7 +312,7 @@ for cut_name, Selection in cuts.iteritems():
 							       )   
 		pobj = process.DYGenMassFilter * pobj
 		     
-	if 'tautau' in name:
+	if 'dyInclusive50' in name:
 		if miniAOD:
 			process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
 			process.DYGenMassFilter = cms.EDFilter('TauTauSelection',
@@ -276,7 +346,7 @@ for cut_name, Selection in cuts.iteritems():
     setattr(process, pathname, path)
 
 
-def ntuplify(process, fill_gen_info=False):
+def ntuplify(process, fill_gen_info=True):
 
 
     if miniAOD:
@@ -286,12 +356,12 @@ def ntuplify(process, fill_gen_info=False):
 
 	process.SimpleNtupler = cms.EDAnalyzer('SimpleNtupler_miniAOD',
                                            dimu_src = cms.InputTag('SimpleMuonsAllSigns'),
-					   met_src = cms.InputTag("slimmedMETs"),
-					   jet_src = cms.InputTag("slimmedJets"),
+						met_src = cms.InputTag("slimmedMETs"),
+						jet_src = cms.InputTag("slimmedJets"),
                                            beamspot_src = cms.InputTag('offlineBeamSpot'),
                                            vertices_src = cms.InputTag('offlineSlimmedPrimaryVertices'),
-#					   TriggerResults_src = cms.InputTag('TriggerResults', '', 'PAT'),
-					   TriggerResults_src = cms.InputTag('TriggerResults', '', 'RECO'),
+								TriggerResults_src = cms.InputTag('TriggerResults', '', 'PAT'),	#mc
+# 								TriggerResults_src = cms.InputTag('TriggerResults', '', 'RECO'),	#data
                                            genEventInfo = cms.untracked.InputTag('generator'),
                                            metFilter = cms.VInputTag( cms.InputTag("Flag_HBHENoiseFilter"), cms.InputTag("Flag_HBHENoiseIsoFilter"), cms.InputTag("Flag_EcalDeadCellTriggerPrimitiveFilter"), cms.InputTag("Flag_eeBadScFilter"), cms.InputTag("Flag_globalTightHalo2016Filter"))
                                            )
@@ -360,9 +430,11 @@ def check_prescale(process, trigger_paths, hlt_process_name='HLT'):
 
 def for_data(process):
     #process.GlobalTag.globaltag ='GR_P_V56'
-    process.GlobalTag.globaltag ='80X_dataRun2_Prompt_v11'
     #process.GlobalTag.globaltag = 'GR_E_V47'
     # process.GlobalTag.globaltag = 'GR_P_V54'
+    
+    process.GlobalTag.globaltag ='80X_dataRun2_2016SeptRepro_v6' #RunB to RunG   #change line 52
+#     process.GlobalTag.globaltag = '80X_dataRun2_Prompt_v14' #RunH              #change line 52
     ntuplify(process)
     #check_prescale(process, trigger_paths) ####### Now it seams that there are no prescaled path ########
 
@@ -429,10 +501,10 @@ config.Data.inputDBS = 'global'
 job_control
 config.Data.publication = False
 config.Data.outputDatasetTag = 'ana_datamc_%(name)s'
-config.Data.outLFNDirBase = '/store/user/federica'
+config.Data.outLFNDirBase = '/store/user/ferrico'
 config.Data.ignoreLocality = True 
-#config.Site.whitelist = ["T2_CH_CERN"]
-config.Site.storageSite = 'T2_IT_Legnaro'
+#config.Site.whitelist = ["T2_IT_Bari"]
+config.Site.storageSite = 'T2_IT_Bari'
 '''
     
     just_testing = 'testing' in sys.argv
@@ -442,7 +514,17 @@ config.Site.storageSite = 'T2_IT_Legnaro'
         from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import *
 
         dataset_details = [
-            ('SingleMuonRun2016G-prompt', '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD'),
+
+						('SingleMuonRun2016B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD'),
+						('SingleMuonRun2016C-ReReco-v1', '/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD'),
+						('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
+						('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
+						('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
+						('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD'),
+# 							('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'), #change global tag: 26 and 408
+# 							('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD'),  ##change global tag: 26 and 408
+
+				# 							('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
 
             ]
 
@@ -450,7 +532,7 @@ config.Site.storageSite = 'T2_IT_Legnaro'
 		# 'NoLumiMask'
 		#           'DCSOnly',
 		#            'Run2012PlusDCSOnlyMuonsOnly',
-		'Run2015MuonsOnly',
+		'Run2016MuonsOnly',
 		# 'Run2015',
 		]
 
@@ -505,7 +587,7 @@ config.Data.lumiMask = '%(lumi_mask)s' #######
 config.Data.splitting = 'EventAwareLumiBased'
 #config.Data.splitting = 'FileBased'
 config.Data.totalUnits = -1
-config.Data.unitsPerJob  = 10000
+config.Data.unitsPerJob  = 100000
     ''')
 
        

--- a/test/DataMCSpectraComparison/tasks.py
+++ b/test/DataMCSpectraComparison/tasks.py
@@ -123,13 +123,13 @@ elif cmd == 'gathermc':
     extra = '_' + extra[0] if extra else ''
     for sample in samples:
         name = sample.name
-        pattern = 'crab/crab_ana%(extra)s_datamc_%(name)s*/results/zp2mu_histos*root' % locals()
+        pattern = 'crab/crab_ana%(extra)s_datamc_%(name)s/results/zp2mu_histos*root' % locals()
         fn = 'ana_datamc_%(name)s.root' % locals()
         n = len(glob.glob(pattern))
         if n == 0:
             big_warn('no files matching %s' % pattern)
         else:
-            files = glob.glob('crab/crab_ana%(extra)s_datamc_%(name)s*/results/zp2mu_histos*root' % locals())
+            files = glob.glob('crab/crab_ana%(extra)s_datamc_%(name)s/results/zp2mu_histos*root' % locals())
             hadd('mc/ana_datamc_%s.root' % name, files)
 
 elif cmd == 'gatherdata':

--- a/test/DataMCSpectraComparison/tasks.py
+++ b/test/DataMCSpectraComparison/tasks.py
@@ -39,10 +39,10 @@ def do(cmd):
 #latest_dataset = '/SingleMu/Run2015A-PromptReco-v1/AOD'
 #latest_dataset = '/ExpressPhysics/Run2015B-Express-v1/FEVT'
 #latest_dataset = '/SingleMuon/Run2015B-PromptReco-v1/AOD'
-latest_dataset = '/SingleMuon/Run2015C-PromptReco-v1/AOD'
+latest_dataset = '/SingleMuon/Run2016C-PromptReco-v2/AOD'
 #lumi_masks = ['Run2012PlusDCSOnlyMuonsOnly', 'Run2012MuonsOnly'] #, 'DCSOnly', 'Run2012']
 #lumi_masks = ['DCSOnly', 'Run2015', 'Run2015MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
-lumi_masks = ['Run2015MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
+lumi_masks = ['Run2016MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
 #lumi_masks = ['DCSOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
 
 
@@ -73,12 +73,30 @@ elif cmd == 'checkstatus':
     for sample in samples:
         print sample.name
         do('crab status -d crab/crab_ana_datamc_%(name)s ' % sample)
+        
+elif cmd == 'report':
+    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+    for sample in samples:
+        print sample.name
+        do('crab report -d crab/crab_ana_datamc_%(name)s ' % sample)
+        
+elif cmd == 'resubmit':
+    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+    for sample in samples:
+        print sample.name
+        do('crab resubmit -d crab/crab_ana_datamc_%(name)s ' % sample)
+
+elif cmd == 'kill':
+    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+    for sample in samples:
+        print sample.name
+        do('crab kill -d crab/crab_ana_datamc_%(name)s ' % sample)
 
 elif cmd == 'getoutput':
     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
     for sample in samples:
         print sample.name
-        do('crab getoutput -d crab/crab_ana_datamc_%(name)s ' % sample)
+        do('crab getoutput -d crab/crab_ana_datamc_%(name)s --checksum=no ' % sample)
 
 #elif cmd == 'publishmc':
 #    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
@@ -105,13 +123,13 @@ elif cmd == 'gathermc':
     extra = '_' + extra[0] if extra else ''
     for sample in samples:
         name = sample.name
-        pattern = 'crab/crab_ana%(extra)s_datamc_%(name)s/results/zp2mu_histos*root' % locals()
+        pattern = 'crab/crab_ana%(extra)s_datamc_%(name)s*/results/zp2mu_histos*root' % locals()
         fn = 'ana_datamc_%(name)s.root' % locals()
         n = len(glob.glob(pattern))
         if n == 0:
             big_warn('no files matching %s' % pattern)
         else:
-            files = glob.glob('crab/crab_ana%(extra)s_datamc_%(name)s/results/zp2mu_histos*root' % locals())
+            files = glob.glob('crab/crab_ana%(extra)s_datamc_%(name)s*/results/zp2mu_histos*root' % locals())
             hadd('mc/ana_datamc_%s.root' % name, files)
 
 elif cmd == 'gatherdata':
@@ -120,7 +138,7 @@ elif cmd == 'gatherdata':
     for lumi_mask in lumi_masks:
         print lumi_mask
 #        dirs = glob.glob('crab/crab_ana_datamc_%s_ExpressPhysicsRun2015B*' % lumi_mask)
-        dirs = glob.glob('crab/crab_ana_datamc_%s_SingleMuonRun2015C*' % lumi_mask)
+        dirs = glob.glob('crab/crab_ana_datamc_%s_SingleMuonRun2016*' % lumi_mask)
 #        dirs = glob.glob('crab/crab_ana_datamc_%s_ExpressPhysicsRun2015B-Express_251161_251252' % lumi_mask)
         files = []
         for d in dirs:
@@ -130,10 +148,10 @@ elif cmd == 'gatherdata':
         os.mkdir(wdir)
         hadd(os.path.join(wdir, 'ana_datamc_data.root'), files)
 
-        for dir in dirs:
-            do('crab status -d %(dir)s ; crab report -d %(dir)s ' % locals())
+#         for dir in dirs:
+#             do('crab status -d %(dir)s ; crab report -d %(dir)s ' % locals())
 
-        jsons = [os.path.join(dir, 'results/lumiSummary.json') for dir in dirs]
+        jsons = [os.path.join(dir, 'results/processedLumis.json') for dir in dirs]
         print jsons
         lls = [(j, LumiList(j)) for j in jsons]
         for (j1, ll1), (j2, ll2) in combinations(lls, 2):
@@ -145,12 +163,13 @@ elif cmd == 'gatherdata':
                 print cl
                                         
         reduce(lambda x,y: x|y, (LumiList(j) for j in jsons)).writeJSON('%(wdir)s/ana_datamc_data.forlumi.json' % locals())
+        do('brilcalc lumi --normtag /afs/cern.ch/user/l/lumipro/public/normtag_file/normtag_DATACERT.json -u /pb  -i %(wdir)s/ana_datamc_data.forlumi.json  > %(wdir)s/ana_datamc_data.lumi -b "STABLE BEAMS" ' % locals())
+        do('tail -5 %(wdir)s/ana_datamc_data.lumi' % locals())
+        print 'done with', lumi_mask, '\n'
+
         #do('lumiCalc2.py -i %(wdir)s/ana_datamc_data.forlumi.json overview > %(wdir)s/ana_datamc_data.lumi' % locals())
         #do('pixelLumiCalc.py -i %(wdir)s/ana_datamc_data.forlumi.json overview > %(wdir)s/ana_datamc_data.lumi' % locals())
 #        do('python /afs/cern.ch/user/m/marlow/public/lcr2/lcr2.py -i %(wdir)s/ana_datamc_data.forlumi.json > %(wdir)s/ana_datamc_data.lumi' % locals())
-        do('brilcalc lumi --normtag /afs/cern.ch/user/c/cmsbril/public/normtag_json/OfflineNormtagV1.json -u /pb  -i %(wdir)s/ana_datamc_data.forlumi.json  > %(wdir)s/ana_datamc_data.lumi' % locals())
-        do('tail -5 %(wdir)s/ana_datamc_data.lumi' % locals())
-        print 'done with', lumi_mask, '\n'
 
 elif cmd == 'runrange':
     #cmd = 'dbs search --query="find min(run),max(run) where dataset=%s"' % latest_dataset
@@ -195,9 +214,9 @@ elif cmd == 'checkavail':
     ll = LumiList(compactList=lumis)
 #print "ll", ll
     runrange = sorted(int(x) for x in ll.getCompactList().keys())
-
+    dcs_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/DCSOnly/json_DCSONLY.txt') # JMTBAD import from goodlumis
     #dcs_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY.txt') # JMTBAD import from goodlumis
-    dcs_ll = LumiList('/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions15/13TeV/DCSOnly/json_DCSONLY.txt') # JMTBAD import from goodlumis
+	
 
     #print "dcs_ll", dcs_ll
     dcs_runrange = sorted(int(x) for x in dcs_ll.getCompactList().keys())

--- a/test/EfficiencyResolutionFromMC/fitdymass_split.py
+++ b/test/EfficiencyResolutionFromMC/fitdymass_split.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+
+import os
+from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
+set_zp2mu_style()
+ROOT.gStyle.SetPadTopMargin(0.02)
+ROOT.gStyle.SetPadRightMargin(0.04)
+ROOT.TH1.AddDirectory(0)
+
+
+# ROOT.gStyle.SetOptStat(0)
+ROOT.gStyle.SetOptFit(111)
+
+# variable = 'DimuonMassVertexConstrained'
+variable = 'DimuonMassVertexConstrained_bb'
+# variable = 'DimuonMassVertexConstrained_be'
+
+low = fitlow = 150
+high = fithigh = 5000
+high_for_data = 2500
+
+# ps = plot_saver('plots/fitdymass/split'+ variable)
+ps = plot_saver('plots/'+ variable)
+
+
+int_lumi = 36295.39
+rebin = 40
+use_non_dy = True
+
+# Masses = [50, 120, 200, 400, 800, 1400, 2300, 3500, 4500]
+
+
+masses  = ['dy50to120', 'dy120to200', 'dy200to400', 'dy400to800', 'dy800to1400', 'dy1400to2300', 'dy2300to3500', 'dy3500to4500', 'dy4500to6000']
+nevents = [2977600, 100000, 100000,  98400, 100000, 100000, 100000, 100000, 100000]
+#sigmas  = [  1915.,  12.2,  1.53, 0.0462, 0.00586, 0.00194, 1.70e-4, 2.21e-5] # in pb, PYTHIA*1.3
+sigmas  = [  1975, 19.32, 2.731, 0.241, 0.01678, 0.00139, 0.00008948, 0.0000041, 4.56E-7]
+weights = [int_lumi / nev * sig for nev,sig in zip(nevents, sigmas)]
+#weights = [x/weights[-1] for x in weights]
+
+hists = []
+hists_dir = '../DataMCSpectraComparison/mc/'
+for m,w in zip(masses, weights):
+    fn = 'ana_datamc_%s.root' % m #if m != 20 else 'ana_datamc_zmumu.root'
+    fn = hists_dir + fn
+    f = ROOT.TFile(fn)
+    d = f.Our2016MuonsPlusMuonsMinusHistos
+    h = d.Get(variable).Clone('%s' % m)
+    h.Rebin(rebin)
+    h.GetXaxis().SetRangeUser(low, high)
+    print m,w
+    h.Scale(w)
+    h.Draw()
+    ps.save('rawmass%s' % m)
+    hists.append(h)
+ 
+if use_non_dy:
+    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
+    non_dy_samples = [WWinclusive, WW200to600, WW600to1200, WW1200to2500, WW2500, 
+    						WZ_skim,
+							ZZ_skim,
+    						WZ_ext, 
+    						ZZ_ext_skim,
+    						Wantitop, tW, 
+    						Wjets, 
+    						ttbar_lep50to500, 
+							ttbar_lep_500to800, 
+							ttbar_lep_800to1200, 
+							ttbar_lep_1200to1800, 
+							ttbar_lep1800toInf,
+							#     						qcd50to80, 
+    						qcd80to120, qcd120to170, 
+    						qcd170to300, 
+    						qcd300to470, qcd470to600, qcd600to800, qcd800to1000, qcd1000to1400, 
+    						qcd1400to1800, qcd1800to2400, qcd2400to3200, qcd3200, 
+    						dyInclusive50
+    						]
+    for sample in non_dy_samples:
+        fn = 'ana_datamc_%s.root' % sample.name
+        fn = hists_dir + fn
+        f = ROOT.TFile(fn)
+        d = f.Our2016MuonsPlusMuonsMinusHistos
+
+        w = sample.partial_weight * int_lumi
+        h = d.Get(variable).Clone('%s' % sample.name)
+        h.Rebin(rebin)
+        h.GetXaxis().SetRangeUser(low, high)
+        h.Scale(w)
+        h.Draw()
+        ps.save('rawmass_%s' % sample.name)
+        print sample.name, w
+        hists.append(h)
+  
+  
+htot = hists[0].Clone()
+
+for j in xrange(1, len(hists)):
+    htot.Add(hists[j])
+
+htot.SetTitle('')
+htot.GetXaxis().SetTitle('reconstructed m(#mu^{+}#mu^{-}) (GeV)')
+htot.GetYaxis().SetTitle('Events/%i GeV/%.1f fb^{-1}' % (rebin, int_lumi/1000)) # assumes original started out with 1 GeV bins, and the xsec is in pb-1.
+
+htot.Draw()
+    
+def fit_it(lo, hi):
+    
+    print " ----------------------------------------------------------------------------------====================== INIZIO "
+
+    htot.Draw()
+    ps.c.Update()
+
+#     fcn = ROOT.TF1("fcn", "(x<=500)*(exp([0] + [1]*x + [2]*x*x)*x**([3])) + \
+#     						(x>500)*(exp([4] + [5]*x + [6]*x*x)*x**([7]))", lo, hi)
+#     fcn.SetParNames("aL", "bL", "cL", "kL", "aH", "bH", "cH", "kH")
+#     fcn.SetParameters(24, -2E-3, -1E-7, -3.5, 24, -2E-3, -1E-7, -3.5)
+    fcn = ROOT.TF1("fcn", "(x <= 500)*(exp([0] + [1]*x + [2]*x*x)*x**([3])) + \
+    					   (x> 500)*(exp([4] + [5]*x + [6]*x*x + [7]*x*x*x)*x**([8]))", lo, hi)
+    fcn.SetParNames("aL", "bL", "cL", "kL", "aH", "bH", "cH", "dH", "kH")
+    fcn.SetParameters(24, -2E-3, -1E-7, -3.5, 24, -2E-3, -1E-7, -1E-10, -3.5)
+
+
+
+#     fcn = ROOT.TF1("fcn", "(x<=500)*(exp([0] + [1]*x + [2]*x*x + [3]*x*x*x)*x**([4])) + \
+#     						(x>500)*(exp([5] + [6]*x + [7]*x*x + [8]*x*x*x)*x**([9]))", lo, hi)
+#     fcn.SetParNames("aL", "bL", "cL", "dL", "kL", "aH", "bH", "cH", "dH", "kH")
+#     fcn.SetParameters(24, -2E-3, -1E-7, -1E-10, -3.5, 24, -2E-3, -1E-7, -1E-10, -3.5)
+
+#     fcn = ROOT.TF1("fcn", "exp([0] + [1]*x + [2]*x*x + [3]*x*x*x)*x**([4])", lo, hi)
+#     fcn = ROOT.TF1("fcn", "exp([0] + [1]*x + [2]*x*x + [3]*x*x*x)*x**([4])", 500, hi)
+#     fcn = ROOT.TF1("fcn", "exp([0] + [1]*x + [2]*x*x + [3]*x*x*x)*x**([4])", lo, 500)
+#     fcn.SetParNames("a", "b", "c", "d", "k")
+#     fcn.SetParameters(24, -2E-3, -1E-7, -1E-10, -3.5)
+    fcn.SetLineColor(ROOT.kBlue)
+    htot.Fit(fcn, 'SREMV')    
+    s = htot.GetListOfFunctions().FindObject("stats")
+    s.SetName("Const")
+    s.SetX1NDC(0.73)
+    s.SetY1NDC(0.69)
+    s.SetY2NDC(0.94)
+    s.SetOptStat(10)
+    s.SetOptFit(11111)
+    s.SetTextColor(ROOT.kBlue)
+
+
+#     fcn_2 = ROOT.TF1("fcn", "exp([0] + [1]*x + [2]*x*x + [3]*x*x*x)*x**([4])", 500, hi)
+#     fcn_2.SetParNames("a", "b", "c", "d", "k")
+#     fcn_2.SetParameters(24, -2E-3, -1E-7, -1E-10, -3.5)
+#     fcn_2.SetLineColor(ROOT.kRed)
+#     htot.Fit(fcn_2, 'SREMV')
+#     htot.Fit(fcn, 'SREMV')  
+#     s_2 = htot.GetListOfFunctions().FindObject("stats")
+#     s_2.SetName("Const")
+#     s_2.SetX1NDC(0.73)
+#     s_2.SetY1NDC(0.44)
+#     s_2.SetY2NDC(0.69)
+#     s_2.SetOptStat(10)
+#     s_2.SetOptFit(11111)
+#     s_2.SetTextColor(ROOT.kRed)
+
+
+    ps.c.Update()   
+
+#     s.Draw("e")
+#     s_2.Draw("e")
+
+    ps.save('mass%i_%i' % (lo, hi), pdf=True, pdf_log=True)
+    
+    htot.GetXaxis().SetRangeUser(0,500)
+    ps.save('mass%i_%i_ZOOM_500' % (lo, hi), pdf=True, pdf_log=True)
+    
+    htot.GetXaxis().SetRangeUser(0,1000)
+    ps.save('mass%i_%i_ZOOM_1000' % (lo, hi), pdf=True, pdf_log=True)
+        
+    ps.c.Update()
+	
+
+    xax = htot.GetXaxis()
+    hres = ROOT.TH1F('hres_%i_%i' % (lo, hi), ';m(#mu^{+}#mu^{-}) (GeV);(fit-hist)/hist', htot.GetNbinsX(), xax.GetBinLowEdge(1), xax.GetBinLowEdge(htot.GetNbinsX()+1))
+    for h in [hres]:
+#        h.GetYaxis().SetLabelSize(0.02)
+        h.SetMarkerStyle(2)
+        h.SetStats(0)
+    for i in xrange(1, hres.GetNbinsX()+1):
+        xlo = xax.GetBinLowEdge(i)
+        xhi = xax.GetBinLowEdge(i+1)
+        if xlo >= lo and xhi <= hi:#and xhi < 500:
+            res = fcn.Integral(xlo, xhi)/(xhi-xlo) - htot.GetBinContent(i)
+            if htot.GetBinContent(i) > 0:
+                hres.SetBinContent(i, res/htot.GetBinContent(i))
+                hres.SetBinError(i, htot.GetBinError(i)/htot.GetBinContent(i))
+#         if xlo >= lo and xhi <= hi and xhi > 500:
+#             res = fcn_2.Integral(xlo, xhi)/(xhi-xlo) - htot.GetBinContent(i)
+#             if htot.GetBinContent(i) > 0:
+#                 hres.SetBinContent(i, res/htot.GetBinContent(i))
+#                 hres.SetBinError(i, htot.GetBinError(i)/htot.GetBinContent(i))
+     
+    hres.SetMinimum(-0.25)
+    hres.SetMaximum(0.25)
+    hres.GetXaxis().SetRangeUser(lo, hi)
+    hres.Draw('e')
+    l1 = ROOT.TLine(lo, 0., hi,  0.)
+    l1.Draw()
+    
+    t = ROOT.TPaveLabel(0.15, 0.825, 0.45, 0.925, "K factor: new", 'brNDC')
+    t.SetTextFont(42)
+    t.SetTextSize(0.5)
+    t.SetBorderSize(0)
+    t.SetFillColor(0)
+    t.SetFillStyle(0)
+#     t.Draw()
+    
+    ps.save('res_%i_%i' % (lo, hi), pdf=True, log=False)
+    
+    ps.c.Update()
+       
+       
+    f_data = ROOT.TFile('/afs/cern.ch/work/f/ferrico/private/ZPrime_code/CMSSW_8_0_21/src/SUSYBSMAnalysis/Zprime2muAnalysis/test/DataMCSpectraComparison/data/NoScale_YesEtaCut_Run2016MuonsOnly/ana_datamc_data.root')
+    c_data = f_data.Our2016MuonsPlusMuonsMinusHistos
+    data = c_data.Get(variable)
+    data.Rebin(rebin)
+    data.SetStats(0)
+    data.GetXaxis().SetTitle('reconstructed m(#mu^{+}#mu^{-}) (GeV)')
+    data.GetYaxis().SetTitle('Events/%i GeV/%.1f fb^{-1}' % (rebin, int_lumi/1000)) # assumes original started out with 1 GeV bins, and the xsec is in pb-1.
+    data.Draw()
+    htot.SetLineColor(ROOT.kRed)
+    htot.GetXaxis().SetRangeUser(lo, hi)
+    htot.Draw("same")
+    htot.Fit(fcn, 'SREMV')
+    htot.GetXaxis().SetRangeUser(lo, high_for_data)
+    data.GetXaxis().SetRangeUser(lo, high_for_data)
+#     htot.SetMinimum(10e-5)
+#     htot.SetMaximum(10e5)
+    data.SetMinimum(10e-6)
+    data.SetMaximum(10e5)
+    ps.save('data_%i_%i' % (lo, hi), pdf_log=True)
+    
+    data.SetMinimum(10)
+    data.GetXaxis().SetRangeUser(0,500)
+    ps.save('data%i_%i_ZOOM_500' % (lo, hi), pdf_log=True)
+
+    data.SetMinimum(1)    
+    data.GetXaxis().SetRangeUser(0,1000)
+    ps.save('data%i_%i_ZOOM_1000' % (lo, hi), pdf_log=True)
+    
+    
+    
+    data.GetXaxis().SetRangeUser(lo, high_for_data)
+    hres = ROOT.TH1F('hres_%i_%i' % (lo, hi), ';m(#mu^{+}#mu^{-}) (GeV);(fit-data)/data', data.GetNbinsX(), xax.GetBinLowEdge(1), xax.GetBinLowEdge(data.GetNbinsX()+1))
+    xax = data.GetXaxis()
+    for h in [hres]:
+#        h.GetYaxis().SetLabelSize(0.02)
+        h.SetMarkerStyle(2)
+        h.SetStats(0)
+    for i in xrange(1, data.GetNbinsX()+1):
+        xlo = xax.GetBinLowEdge(i)
+        xhi = xax.GetBinLowEdge(i+1)
+        if xlo >= lo and xhi <= hi:
+#             print data.GetBinContent(i)
+            res = fcn.Integral(xlo, xhi)/(xhi-xlo) - data.GetBinContent(i)
+#             print res, data.GetBinContent(i), xlo, xhi
+            if data.GetBinContent(i) > 0:
+                hres.SetBinContent(i, res/data.GetBinContent(i))
+                hres.SetBinError(i, data.GetBinError(i)/data.GetBinContent(i))
+            if data.GetBinContent(i) == 0:
+                hres.SetBinContent(i, 1)
+                hres.SetBinError(i, 0)
+
+
+    hres.SetMinimum(-1)
+    hres.SetMaximum( 1)
+    hres.GetXaxis().SetRangeUser(lo, high_for_data)
+    hres.Draw('e')
+    l1 = ROOT.TLine(lo, 0., high_for_data,  0.)
+    l1.Draw()
+
+#     t = ROOT.TPaveLabel(0.15, 0.825, 0.45, 0.925, "K factor: old", 'brNDC')
+#     t.SetTextFont(42)
+#     t.SetTextSize(0.5)
+#     t.SetBorderSize(0)
+#     t.SetFillColor(0)
+#     t.SetFillStyle(0)
+#     t.Draw()
+    
+    ps.save('res_%i_%i_data' % (lo, hi), pdf=True, log=False)
+ 
+    ps.c.Update() 
+ 
+ 
+ 
+    
+#    print fcn.GetProb(), fcn.GetParameter(2), fcn.GetParError(2)
+#     c = r.GetCovarianceMatrix()
+#     r.Print("V")
+#     print " ----------------------------------------------------------------------------------====================== FINE "
+#     print c
+	
+	
+
+#l = range(200, 2200, 200)
+# l = [60, 120, 140, 160, 200]
+l = [150]
+for lo in l:
+    print " ----------------------------------------------------------------------------------->>>>>>>>>>>>>>>>>>>>> %d " %lo
+    fit_it(lo, high)
+    
+print " ------------------------------------------------------------------------- Passo al Draw "
+print variable, high
+#fit_it(400,2000)
+
+# Take different Drell-Yan mass spectra and plot them overlayed,
+# then calculate and plot their ratios.
+#fsets = ["", "_c1", "_c2"]
+# draw_overlay(fsets)

--- a/test/NMinus1Effs/nm1entry.py
+++ b/test/NMinus1Effs/nm1entry.py
@@ -9,54 +9,99 @@ from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
 from SUSYBSMAnalysis.Zprime2muAnalysis.roottools import *
 set_zp2mu_style()
 
-lumiBCD = 2800.
+
+
+#tt = 'tt pow'
+tt = 'tt lep'
+
+# lumi = 20409.950
+# period = 'BF'
+# period_1 = 'RunB - RunF'
+
+# lumi = 16786.820
+# period = 'GH' 
+# period_1 = 'RunG - RunH'
+
+lumi = 36295.39
+period = '' 
+
+folder = 'LeptonPt'
+axisX = 'p_{T}(#mu) [GeV]'
+# folder = 'DileptonPt'
+# folder = 'NTkLayers'
+# folder = 'RelIsoSumPt'
+# folder = 'NPxHits'
+# folder = 'DimuonMuonPtErrOverPt'
+# folder = 'DimuonMassVtx_chi2'
+# axisX = 'Vtx #chi^{2}'
+
+# folder = 'DileptonMass'
+# folder = 'DileptonMass_bb'
+# folder = 'DileptonMass_be'
+# folder = 'DimuonMassVertexConstrained'
+# axisX = 'm(#mu#mu) [GeV]'
+# folder = 'DimuonMassVertexConstrained_bb'
+# folder = 'DimuonMassVertexConstrained_be'
 
 styles = {
 #    'sample':    (color, draw/fill style),
-    'dataB':      (ROOT.kBlack,     -1),
+    'data':      (ROOT.kBlack,     -1),
     'dataCD':      (ROOT.kBlack,     -1),
     'dataBCD':      (ROOT.kBlack,     -1),
-    'mc_samples_50m120': (ROOT.kGreen+2,1001),
-    'mc_samples_120m': (ROOT.kGreen+2,1001),
-    #'dy50to120':(ROOT.kGreen, 1001),
-    #'dy120to200':(ROOT.kGreen-4, 1001),
-    #'dy200to400':(ROOT.kGreen+1, 1001),
-    #'dy400to800':(ROOT.kGreen-7, 1001),
-    #'dy800to1400':(ROOT.kGreen-3, 1001),
-    #'dy1400to2300':(ROOT.kGreen+2, 1001),
-    #'dy2300to3500':(ROOT.kGreen-9, 1001),
-    #'dy3500to4500':(ROOT.kGreen-6, 1001),
-    #'dy4500to6000':(ROOT.kGreen-2, 1001),
-    'dy50to120':(ROOT.kGreen+2, 1001),
-    'dy120to200':(ROOT.kGreen+2, 1001),
-    'dy200to400':(ROOT.kGreen+2, 1001),
-    'dy400to800':(ROOT.kGreen+2, 1001),
-    'dy800to1400':(ROOT.kGreen+2, 1001),
-    'dy1400to2300':(ROOT.kGreen+2, 1001),
-    'dy2300to3500':(ROOT.kGreen+2, 1001),
-    'dy3500to4500':(ROOT.kGreen+2, 1001),
-    'dy4500to6000':(ROOT.kGreen+2, 1001),
-    'dy6000':(ROOT.kGreen+2, 1001),
+
+
+#                                 return 'DY #rightarrow #tau#tau', 5
+#                         else:
+#                                 return  'DY #rightarrow #mu#mu', 3
+ 
+  
+     
+          
+    'dyInclusive50': (5,1001),
+    'dy50to120':(3, 1001),
+    'dy120to200':(3, 1001),
+    'dy200to400':(3, 1001),
+    'dy400to800':(3, 1001),
+    'dy800to1400':(3, 1001),
+    'dy1400to2300':(3, 1001),
+    'dy2300to3500':(3, 1001),
+    'dy3500to4500':(3, 1001),
+    'dy4500to6000':(3, 1001),
+#    'dy6000':(ROOT.kGreen+2, 1001),
+    'ttbar_lep':(4,1001),
+    'ttbar_lep50to500':(4,1001),
+    'ttbar_lep50to800':(4,1001),
+    'ttbar_lep_500to800':(4,1001),
+    'ttbar_lep_800to1200':(4,1001),
+    'ttbar_lep_1200to1800':(4,1001),
+    'ttbar_lep_1800':(4,1001),
     'ttbar_pow':(ROOT.kBlue,1001),
-    'ww_incl':(ROOT.kOrange,1001),
-    'zz_incl':(ROOT.kOrange,1001),
-    'wz':(ROOT.kOrange,1001),
-    'tWtop':(ROOT.kYellow,1001),
-    'tWantitop':(ROOT.kYellow,1001),
-    'wjets':(ROOT.kViolet,1001),
-    'qcd50to80':(ROOT.kViolet,1001),
-    'qcd80to120':(ROOT.kViolet,1001),
-    'qcd120to170':(ROOT.kViolet,1001),
-    'qcd170to300':(ROOT.kViolet,1001),
-    'qcd300to470':(ROOT.kViolet,1001),
-    'qcd470to600':(ROOT.kViolet,1001),
-    'qcd600to800':(ROOT.kViolet,1001),
-    'qcd800to1000':(ROOT.kViolet,1001),
-    'qcd1000to1400':(ROOT.kViolet,1001),
-    'qcd1400to1800':(ROOT.kViolet,1001),
-    'qcd1800to2400':(ROOT.kViolet,1001),
-    'qcd2400to3200':(ROOT.kViolet,1001),
-    'qcd3200':(ROOT.kViolet,1001),
+    'WWinclusive':(ROOT.kRed-10,1001),
+    'WW200to600':(ROOT.kRed-10,1001),
+    'WW600to1200':(ROOT.kRed-10,1001),
+    'WW1200to2500':(ROOT.kRed-10,1001),
+    'WW2500':(ROOT.kRed-10,1001),
+    'ZZ':(2,1001),
+    'ZZ_ext':(2,1001),
+    'WZ':(ROOT.kRed+3,1001),
+    'WZ_ext':(ROOT.kRed+3,1001),
+    'tW':(ROOT.kBlue+2,1001),
+    'Wantitop':(ROOT.kBlue+2,1001),
+    'Wjets':(7,1001),
+    'qcd80to120':(20,1001),
+    'qcd120to170':(20,1001),
+    'qcd170to300':(20,1001),
+    'qcd300to470':(20,1001),
+    'qcd470to600':(20,1001),
+    'qcd600to800':(20,1001),
+    'qcd800to1000':(20,1001),
+    'qcd1000to1400':(20,1001),
+    'qcd1400to1800':(20,1001),
+    'qcd1800to2400':(20,1001),
+    'qcd2400to3200':(20,1001),
+    'qcd3200':(20,1001),
+
+
 }
 
 nminus1s = [
@@ -107,7 +152,9 @@ pretty = {
     'dataB': 'Data RunB, %.1f fb^{-1}, MuonOnly',
     'dataCD': 'Data RunC+D, %.1f fb^{-1}, MuonOnly',
     'dataBCD': 'Data, %.1f fb^{-1}, 2015 MuonOnly',
+    'all': 'm > 60 GeV',
     '120m': 'm > 120 GeV',
+    '500m': 'm > 500 GeV',
     '60m120': '60 < m < 120 GeV',
     'zpsi5000': 'Z\'_{#psi}, M=5000 GeV',
     'dy50to120': 'DY#rightarrow#mu#mu 50 < m < 120 GeV',
@@ -120,6 +167,12 @@ pretty = {
     'dy3500to4500': 'DY#rightarrow#mu#mu 3500 < m < 4500 GeV',
     'dy4500to6000': 'DY#rightarrow#mu#mu 4500 < m < 6000 GeV',
     'dy6000': 'DY#rightarrow#mu#mu m > 6000 GeV',
+    'ttbar_lep': 't#bar{t} lep',
+    'ttbar_lep50to500': 't#bar{t} lep 50 < m < 500 GeV',
+    'ttbar_lep50to800': 't#bar{t} lep 50 < m < 500 GeV',
+    'ttbar_lep_800to1200': 't#bar{t} lep',
+    'ttbar_lep_1200to1800': 't#bar{t} lep',
+    'ttbar_lep1800toInf': 't#bar{t} lep',
     'ttbar_pow': 't#bar{t} powheg',
     'ww_incl': 'WW',
     'zz_incl': 'ZZ',
@@ -234,10 +287,13 @@ def table_wald(entry,nminus1, mass_range):
             else:
                 errw = (eff*(1-eff)/den)**0.5
         if 'data' not in entry.name:
-            num = num*entry.partial_weight*lumiBCD
-            den = den*entry.partial_weight*lumiBCD
+        	num = num*entry.partial_weight*lumi
+        	den = den*entry.partial_weight*lumi
+#         print '%20s%15i%15i%20f%20f%15f%15f%15f%23f'     % (nminus1, mlow, mhigh, num, den, eff, eff-lcp, hcp-eff,        errw)
+#         print '%20s%15i%15i%20f%20f%15f%15f%15f%15f%16f' % (nminus1, mlow, mhigh, num, den, eff, lcp,     hcp,     eff-errw, eff+errw)
         print '%20s%15i%15i%20f%20f%15f%15f%15f%23f'     % (nminus1, mlow, mhigh, num, den, eff, eff-lcp, hcp-eff,        errw)
         print '%20s%15i%15i%20f%20f%15f%15f%15f%15f%16f' % (nminus1, mlow, mhigh, num, den, eff, lcp,     hcp,     eff-errw, eff+errw)
+
         print ' '
     print '---------------------------------------------'
 
@@ -259,8 +315,8 @@ def table(entry,nminus1, mass_range):
 class nm1entry:
     def __init__(self, sample, is_data, lumi):
         if type(sample) == str:
-            self.name = sample
-            self.fn = 'data/ana_nminus1_%s.root' %sample
+            self.name = sample      
+            self.fn = '/afs/cern.ch/work/f/ferrico/private/ZPrime_code/CMSSW_8_0_21/src/SUSYBSMAnalysis/Zprime2muAnalysis/test/NMinus1Effs/data/Run2016MuonsOnly%s/ana_nminus1_data.root' %period
             #self.fn = self.make_fn(sample) if is_data else None
             self.lumi = lumi if is_data else None
             self.is_data = is_data
@@ -272,15 +328,20 @@ class nm1entry:
         self.prepare_histos()
             
 
-    def make_fn(self, name):
-        return 'mc/ana_nminus1_%s.root' % name
+    def make_fn(self, name):   
+        #return 'mc/ana_nminus1_%s.root' % name
+        return '/afs/cern.ch/work/f/ferrico/private/ZPrime_code/CMSSW_8_0_21/src/SUSYBSMAnalysis/Zprime2muAnalysis/test/NMinus1Effs/mc/ana_nminus1_%s.root' %  name       
+        #return 'mc_TriggerScale/ana_nminus1_%s.root' % name
+        
+        
     
     def prepare_histos(self):
         self.histos = {}
         if self.fn is not None:
             f = ROOT.TFile(self.fn)
             for nminus1 in nminus1s + ['NoNo']:
-                self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
+                self.histos[nminus1] = f.Get(nminus1).Get(folder).Clone()
+#                self.histos[nminus1] = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
 
     # This function isn't used anymore, but keep for posterity? cjsbad
     def prepare_histos_sum(self, samples, lumi):
@@ -290,7 +351,8 @@ class nm1entry:
             print '%20s%20s%21s%20s%20s' % ('cut', 'sampe name', 'partial weight', 'scale(ref)','scale(lumi)')
             for sample in samples:
                 f = ROOT.TFile(self.make_fn(sample.name))
-                h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
+                #h = f.Get(nminus1).Get('DimuonMassVertexConstrained').Clone()
+                h = f.Get(nminus1).Get(folder).Clone()
                 if lumi>0:
                     # scale to luminosity for comparision of single dataset to MC
                     h.Scale(sample.partial_weight * lumi) 
@@ -302,5 +364,4 @@ class nm1entry:
             for h in hs[1:]:
                 hsum.Add(h)
             self.histos[nminus1] = hsum
-
 

--- a/test/NMinus1Effs/nminus1effs_TauTau.py
+++ b/test/NMinus1Effs/nminus1effs_TauTau.py
@@ -11,8 +11,8 @@ if miniAOD:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT_MiniAOD as HistosFromPAT
 else:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT
-# from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
-from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
+from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
+#from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
 
 #### if you run on data change HLT2 in
 ##Zprime2muAnalysis_cff
@@ -27,10 +27,19 @@ secFiles = cms.untracked.vstring()
 
 process.source = cms.Source ("PoolSource",
                              fileNames =  cms.untracked.vstring(
+# '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00312D7A-FEBD-E611-A713-002590DB923E.root',
+# '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00355459-F4BD-E611-B5E8-D4AE526A11F3.root',
+# '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/00BCC036-F6BD-E611-92F5-0025905A6118.root',
+# '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/028EE230-F7BD-E611-BCDB-0CC47AA9906E.root',
+# '/store/mc/RunIISummer16MiniAODv2/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/MINIAODSIM/PUMoriond17_HCALDebug_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/50000/02C57965-0DBE-E611-91EF-70106F4A9254.root',
 
-'/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0030B9D6-72C1-E611-AE49-02163E00E602.root',
+
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/06BD3929-EDC7-E611-8EC3-02163E019C96.root',
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/88E1539B-0AC8-E611-B36F-02163E0140DC.root'
+
 #                                                                 '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/162AD1DB-1E98-E611-9893-008CFA56D58C.root',
                                                                 #'/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/1A1F07FF-2698-E611-915C-0242AC130004.root'
+#                                                                '/store/mc/RunIISpring16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/90000/18C80393-613A-E611-86DF-0090FAA573E0.root'
                                                                 ),
                              secondaryFileNames = secFiles)
 
@@ -42,6 +51,11 @@ secFiles.extend( [
 process.maxEvents.input = -1
 process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'
 #process.MessageLogger.cerr.FwkReport.reportEvery = 1 # default 1000
+
+process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
+process.DYGenMassFilter = cms.EDFilter('TauTauSelection',
+                                       src = cms.InputTag('prunedGenParticles'),
+                                       )
 
 # Define the numerators and denominators, removing cuts from the
 # allDimuons maker. "NoX" means remove cut X entirely (i.e. the
@@ -58,8 +72,8 @@ cuts = [
     ('TkLayers','globalTrack.hitPattern.trackerLayersWithMeasurement > 5'),
     ('PxHits',  'globalTrack.hitPattern.numberOfValidPixelHits >= 1'),
     ('MuHits',  'globalTrack.hitPattern.numberOfValidMuonHits > 0'),
-#     ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
-    ('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
+    ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
+    #('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
     ]
 
 for name, cut in cuts:
@@ -94,9 +108,8 @@ for x in alldimus:
 
 if miniAOD:
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.DileptonPreselector_cfi')####?????
-    process.load("SUSYBSMAnalysis.Zprime2muAnalysis.EventCounter_cfi")
     process.leptons = process.leptonsMini.clone()
-    process.p = cms.Path(process.egmGsfElectronIDSequence*process.EventCounter * process.dileptonPreseletor * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
+    process.p = cms.Path(process.egmGsfElectronIDSequence*process.dileptonPreseletor *  process.DYGenMassFilter * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.goodData_cff')
     for dataFilter in goodDataFiltersMiniAOD:
         #setattr(process,dataFilter
@@ -157,9 +170,10 @@ config.General.requestName = 'ana_nminus1_%(name)s'
 config.General.workArea = 'crab'
 #config.General.transferLogs = True
 config.JobType.pluginName = 'Analysis'
-config.JobType.psetName = 'nminus1effs.py'
+config.JobType.psetName = 'nminus1effs_TauTau.py'
 #config.JobType.priority = 1
-config.Data.inputDataset =  '%(dataset)s' 
+#config.Data.inputDataset =  '%(ana_dataset)s' #for pattuples
+config.Data.inputDataset =  '%(dataset)s' # for miniAOD
 config.Data.inputDBS = 'global'
 job_control
 config.Data.publication = False
@@ -175,42 +189,25 @@ config.Site.storageSite = 'T2_IT_Bari'
         #from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import Run2016G_ll
         #Run2016G_ll.writeJSON('tmp.json')
 
-        from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import *
-        
         dataset_details = [
- 						('SingleMuonRun2017B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD'),
- 						('SingleMuonRun2016C-ReReco-v1', '/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
-						('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
-				########  RUN G PROMPT		('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
- 						('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD'),
-# 						('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'), #change global tag: 199
-# 						('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD'),  ##change global tag: 199
-
+                           #                 ('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
+                           #                ('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
+                           #               ('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
+                           #              ('SingleMuonRun2016C-ReReco-v1','/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD')
+                           #             ('SingleMuonRun2016B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD')
+                           #            ('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
+                           #              ('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'),
+#                            ('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD') 
+                           #	    ('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD')
             ]
 
-        lumi_lists = [
-			'Run2016MuonsOnly',
-		]
+#        for name, ana_dataset in dataset_details: # for pattuples
+        for name, dataset in dataset_details:
 
-        jobs = []
-        for lumi_name in lumi_lists:
-            ll = eval(lumi_name + '_ll') if lumi_name != 'NoLumiMask' else None
-            for dd in dataset_details:
-                jobs.append(dd + (lumi_name, ll))
-
-
-        for dataset_name, ana_dataset, lumi_name, lumi_list in jobs:
-            json_fn = 'tmp.json'
-            lumi_list.writeJSON(json_fn)
-            lumi_mask = json_fn
-
-            name = '%s_%s' % (lumi_name, dataset_name)
             print name
 
             new_py = open('nminus1effs.py').read()
-            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_Prompt_v14'\n"  #### RunH
+            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'\n"
             open('nminus1effs_crab.py', 'wt').write(new_py)
 
             new_crab_cfg = crab_cfg % locals()
@@ -219,14 +216,13 @@ config.Data.splitting = 'LumiBased'
 config.Data.totalUnits = -1
 config.Data.unitsPerJob = 100
 #config.Data.lumiMask = 'tmp.json' #######
-# config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_MuonPhys.txt'
-config.Data.lumiMask = '%(lumi_mask)s' #######
+config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-282037_13TeV_PromptReco_Collisions16_JSON_NoL1T_MuonPhys.txt'
 '''
             new_crab_cfg = new_crab_cfg.replace('job_control', job_control)
             open('crabConfig.py', 'wt').write(new_crab_cfg)
 
             if not just_testing:
-                os.system('crab submit -c crabConfig.py') #--dryrun
+                os.system('crab submit -c crabConfig.py ') #--dryrun
 
         if not just_testing:
             os.system('rm crabConfig.py nminus1effs_crab.py nminus1effs_crab.pyc tmp.json')
@@ -240,21 +236,8 @@ config.Data.unitsPerJob  = 100000
 
         from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
         #samples =[DY120to200Powheg]
-        samples =[
- 				dy50to120, dy120to200, dy200to400, dy400to800, dy800to1400, 
- 				dy1400to2300, dy2300to3500, dy3500to4500, dy4500to6000,
- 				WZ, ZZ,
-				WZ_ext, ZZ_ext, 
- 				WW200to600, WW600to1200, WW1200to2500, WW2500,
- 				Wjets, Wantitop, tW,
- 				ttbar_lep_800to1200, ttbar_lep_1200to1800, ttbar_lep1800toInf, 
- 				qcd50to80, qcd80to120, qcd120to170, qcd170to300, qcd300to470, qcd470to600, 
- 				qcd600to800, qcd800to1000, qcd1000to1400, qcd1400to1800, qcd1800to2400, qcd2400to3200, qcd3200
-
-
-
-
-                  ]
+        samples =[ dyInclusive50 ]
+        
         for sample in samples:
             #print sample.name
             open('crabConfig.py', 'wt').write(crab_cfg % sample)

--- a/test/NMinus1Effs/nminus1effs_WW.py
+++ b/test/NMinus1Effs/nminus1effs_WW.py
@@ -11,8 +11,8 @@ if miniAOD:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT_MiniAOD as HistosFromPAT
 else:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT
-# from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
-from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
+from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
+#from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
 
 #### if you run on data change HLT2 in
 ##Zprime2muAnalysis_cff
@@ -27,10 +27,15 @@ secFiles = cms.untracked.vstring()
 
 process.source = cms.Source ("PoolSource",
                              fileNames =  cms.untracked.vstring(
-
-'/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0030B9D6-72C1-E611-AE49-02163E00E602.root',
+'/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/265C6533-CDB6-E611-9E71-0090FAA58B94.root',
+'/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/287ADB8D-E1B6-E611-8332-00259073E4EA.root',
+'/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/309E843E-CFB6-E611-9E6F-00259073E496.root',
+# '/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/08E155A9-FAB6-E611-92BF-00259073E45E.root',
+# '/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/0CB16E4E-F0B6-E611-9D13-0090FAA58294.root',
+# '/store/mc/RunIISummer16MiniAODv2/WWTo2L2Nu_13TeV-powheg/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/80000/1AA5E3E6-F4B6-E611-8A54-0090FAA575E0.root',
 #                                                                 '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/162AD1DB-1E98-E611-9893-008CFA56D58C.root',
                                                                 #'/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/1A1F07FF-2698-E611-915C-0242AC130004.root'
+#                                                                '/store/mc/RunIISpring16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/90000/18C80393-613A-E611-86DF-0090FAA573E0.root'
                                                                 ),
                              secondaryFileNames = secFiles)
 
@@ -42,6 +47,13 @@ secFiles.extend( [
 process.maxEvents.input = -1
 process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'
 #process.MessageLogger.cerr.FwkReport.reportEvery = 1 # default 1000
+
+process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
+process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
+                                       src = cms.InputTag('prunedGenParticles'),
+                                       min_mass = cms.double(50),
+                                       max_mass = cms.double(200),
+                                       )
 
 # Define the numerators and denominators, removing cuts from the
 # allDimuons maker. "NoX" means remove cut X entirely (i.e. the
@@ -58,8 +70,8 @@ cuts = [
     ('TkLayers','globalTrack.hitPattern.trackerLayersWithMeasurement > 5'),
     ('PxHits',  'globalTrack.hitPattern.numberOfValidPixelHits >= 1'),
     ('MuHits',  'globalTrack.hitPattern.numberOfValidMuonHits > 0'),
-#     ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
-    ('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
+    ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
+    #('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
     ]
 
 for name, cut in cuts:
@@ -96,7 +108,7 @@ if miniAOD:
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.DileptonPreselector_cfi')####?????
     process.load("SUSYBSMAnalysis.Zprime2muAnalysis.EventCounter_cfi")
     process.leptons = process.leptonsMini.clone()
-    process.p = cms.Path(process.egmGsfElectronIDSequence*process.EventCounter * process.dileptonPreseletor * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
+    process.p = cms.Path(process.egmGsfElectronIDSequence*process.EventCounter * process.dileptonPreseletor * process.DYGenMassFilter * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.goodData_cff')
     for dataFilter in goodDataFiltersMiniAOD:
         #setattr(process,dataFilter
@@ -157,9 +169,10 @@ config.General.requestName = 'ana_nminus1_%(name)s'
 config.General.workArea = 'crab'
 #config.General.transferLogs = True
 config.JobType.pluginName = 'Analysis'
-config.JobType.psetName = 'nminus1effs.py'
+config.JobType.psetName = 'nminus1effs_WW.py'
 #config.JobType.priority = 1
-config.Data.inputDataset =  '%(dataset)s' 
+#config.Data.inputDataset =  '%(ana_dataset)s' #for pattuples
+config.Data.inputDataset =  '%(dataset)s' # for miniAOD
 config.Data.inputDBS = 'global'
 job_control
 config.Data.publication = False
@@ -175,42 +188,25 @@ config.Site.storageSite = 'T2_IT_Bari'
         #from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import Run2016G_ll
         #Run2016G_ll.writeJSON('tmp.json')
 
-        from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import *
-        
         dataset_details = [
- 						('SingleMuonRun2017B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD'),
- 						('SingleMuonRun2016C-ReReco-v1', '/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
-						('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
-				########  RUN G PROMPT		('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
- 						('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD'),
-# 						('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'), #change global tag: 199
-# 						('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD'),  ##change global tag: 199
-
+                           #                 ('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
+                           #                ('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
+                           #               ('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
+                           #              ('SingleMuonRun2016C-ReReco-v1','/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD')
+                           #             ('SingleMuonRun2016B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD')
+                           #            ('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
+                           #              ('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'),
+#                            ('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD') 
+                           #	    ('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD')
             ]
 
-        lumi_lists = [
-			'Run2016MuonsOnly',
-		]
+#        for name, ana_dataset in dataset_details: # for pattuples
+        for name, dataset in dataset_details:
 
-        jobs = []
-        for lumi_name in lumi_lists:
-            ll = eval(lumi_name + '_ll') if lumi_name != 'NoLumiMask' else None
-            for dd in dataset_details:
-                jobs.append(dd + (lumi_name, ll))
-
-
-        for dataset_name, ana_dataset, lumi_name, lumi_list in jobs:
-            json_fn = 'tmp.json'
-            lumi_list.writeJSON(json_fn)
-            lumi_mask = json_fn
-
-            name = '%s_%s' % (lumi_name, dataset_name)
             print name
 
             new_py = open('nminus1effs.py').read()
-            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_Prompt_v14'\n"  #### RunH
+            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'\n"
             open('nminus1effs_crab.py', 'wt').write(new_py)
 
             new_crab_cfg = crab_cfg % locals()
@@ -219,14 +215,13 @@ config.Data.splitting = 'LumiBased'
 config.Data.totalUnits = -1
 config.Data.unitsPerJob = 100
 #config.Data.lumiMask = 'tmp.json' #######
-# config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_MuonPhys.txt'
-config.Data.lumiMask = '%(lumi_mask)s' #######
+config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-282037_13TeV_PromptReco_Collisions16_JSON_NoL1T_MuonPhys.txt'
 '''
             new_crab_cfg = new_crab_cfg.replace('job_control', job_control)
             open('crabConfig.py', 'wt').write(new_crab_cfg)
 
             if not just_testing:
-                os.system('crab submit -c crabConfig.py') #--dryrun
+                os.system('crab submit -c crabConfig.py ') #--dryrun
 
         if not just_testing:
             os.system('rm crabConfig.py nminus1effs_crab.py nminus1effs_crab.pyc tmp.json')
@@ -235,26 +230,13 @@ config.Data.lumiMask = '%(lumi_mask)s' #######
         crab_cfg = crab_cfg.replace('job_control','''
 config.Data.splitting = 'EventAwareLumiBased'
 config.Data.totalUnits = -1
-config.Data.unitsPerJob  = 100000
+config.Data.unitsPerJob  = 10000
 ''')
 
         from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
         #samples =[DY120to200Powheg]
-        samples =[
- 				dy50to120, dy120to200, dy200to400, dy400to800, dy800to1400, 
- 				dy1400to2300, dy2300to3500, dy3500to4500, dy4500to6000,
- 				WZ, ZZ,
-				WZ_ext, ZZ_ext, 
- 				WW200to600, WW600to1200, WW1200to2500, WW2500,
- 				Wjets, Wantitop, tW,
- 				ttbar_lep_800to1200, ttbar_lep_1200to1800, ttbar_lep1800toInf, 
- 				qcd50to80, qcd80to120, qcd120to170, qcd170to300, qcd300to470, qcd470to600, 
- 				qcd600to800, qcd800to1000, qcd1000to1400, qcd1400to1800, qcd1800to2400, qcd2400to3200, qcd3200
-
-
-
-
-                  ]
+        samples =[ WWinclusive ]
+        
         for sample in samples:
             #print sample.name
             open('crabConfig.py', 'wt').write(crab_cfg % sample)

--- a/test/NMinus1Effs/nminus1effs_tt.py
+++ b/test/NMinus1Effs/nminus1effs_tt.py
@@ -11,8 +11,8 @@ if miniAOD:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT_MiniAOD as HistosFromPAT
 else:
     from SUSYBSMAnalysis.Zprime2muAnalysis.HistosFromPAT_cfi import HistosFromPAT
-# from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
-from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
+from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelectionDec2012_cff import loose_cut, trigger_match, tight_cut, allDimuons
+#from SUSYBSMAnalysis.Zprime2muAnalysis.OurSelection2016_cff import loose_cut, trigger_match, tight_cut, allDimuons
 
 #### if you run on data change HLT2 in
 ##Zprime2muAnalysis_cff
@@ -27,10 +27,16 @@ secFiles = cms.untracked.vstring()
 
 process.source = cms.Source ("PoolSource",
                              fileNames =  cms.untracked.vstring(
-
 '/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/0030B9D6-72C1-E611-AE49-02163E00E602.root',
+'/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/00ED79D3-CFC1-E611-B748-3417EBE64483.root',
+'/store/mc/RunIISummer16MiniAODv2/TTTo2L2Nu_TuneCUETP8M2_ttHtranche3_13TeV-powheg-pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/02920749-4EC1-E611-8C82-24BE05C6D711.root',
+
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/06BD3929-EDC7-E611-8EC3-02163E019C96.root',
+# '/store/mc/RunIISummer16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_3500_4500/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/120000/88E1539B-0AC8-E611-B36F-02163E0140DC.root'
+
 #                                                                 '/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/162AD1DB-1E98-E611-9893-008CFA56D58C.root',
                                                                 #'/store/data/Run2016B/SingleMuon/MINIAOD/23Sep2016-v3/00000/1A1F07FF-2698-E611-915C-0242AC130004.root'
+#                                                                '/store/mc/RunIISpring16MiniAODv2/ZToMuMu_NNPDF30_13TeV-powheg_M_120_200/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14-v1/90000/18C80393-613A-E611-86DF-0090FAA573E0.root'
                                                                 ),
                              secondaryFileNames = secFiles)
 
@@ -42,6 +48,13 @@ secFiles.extend( [
 process.maxEvents.input = -1
 process.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'
 #process.MessageLogger.cerr.FwkReport.reportEvery = 1 # default 1000
+
+process.load('SUSYBSMAnalysis.Zprime2muAnalysis.PrunedMCLeptons_cfi')
+process.DYGenMassFilter = cms.EDFilter('DibosonGenMass',
+                                       src = cms.InputTag('prunedGenParticles'),
+                                       min_mass = cms.double(50),
+                                       max_mass = cms.double(500),
+                                       )
 
 # Define the numerators and denominators, removing cuts from the
 # allDimuons maker. "NoX" means remove cut X entirely (i.e. the
@@ -58,8 +71,8 @@ cuts = [
     ('TkLayers','globalTrack.hitPattern.trackerLayersWithMeasurement > 5'),
     ('PxHits',  'globalTrack.hitPattern.numberOfValidPixelHits >= 1'),
     ('MuHits',  'globalTrack.hitPattern.numberOfValidMuonHits > 0'),
-#     ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
-    ('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
+    ('MuMatch', ('numberOfMatchedStations > 1', 'isTrackerMuon')),
+    #('MuMatch', ('( numberOfMatchedStations > 1 || (numberOfMatchedStations == 1 && !(stationMask == 1 || stationMask == 16)) || (numberOfMatchedStations == 1 && (stationMask == 1 || stationMask == 16) && numberOfMatchedRPCLayers > 2))', 'isTrackerMuon')),
     ]
 
 for name, cut in cuts:
@@ -96,7 +109,8 @@ if miniAOD:
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.DileptonPreselector_cfi')####?????
     process.load("SUSYBSMAnalysis.Zprime2muAnalysis.EventCounter_cfi")
     process.leptons = process.leptonsMini.clone()
-    process.p = cms.Path(process.egmGsfElectronIDSequence*process.EventCounter * process.dileptonPreseletor * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
+    process.p = cms.Path(process.egmGsfElectronIDSequence*process.EventCounter * process.dileptonPreseletor * process.DYGenMassFilter * process.muonPhotonMatchMiniAOD * process.leptons * reduce(lambda x,y: x*y, [getattr(process, x) for x in alldimus]))
+
     process.load('SUSYBSMAnalysis.Zprime2muAnalysis.goodData_cff')
     for dataFilter in goodDataFiltersMiniAOD:
         #setattr(process,dataFilter
@@ -157,9 +171,10 @@ config.General.requestName = 'ana_nminus1_%(name)s'
 config.General.workArea = 'crab'
 #config.General.transferLogs = True
 config.JobType.pluginName = 'Analysis'
-config.JobType.psetName = 'nminus1effs.py'
+config.JobType.psetName = 'nminus1effs_tt.py'
 #config.JobType.priority = 1
-config.Data.inputDataset =  '%(dataset)s' 
+#config.Data.inputDataset =  '%(ana_dataset)s' #for pattuples
+config.Data.inputDataset =  '%(dataset)s' # for miniAOD
 config.Data.inputDBS = 'global'
 job_control
 config.Data.publication = False
@@ -175,42 +190,25 @@ config.Site.storageSite = 'T2_IT_Bari'
         #from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import Run2016G_ll
         #Run2016G_ll.writeJSON('tmp.json')
 
-        from SUSYBSMAnalysis.Zprime2muAnalysis.goodlumis import *
-        
         dataset_details = [
- 						('SingleMuonRun2017B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD'),
- 						('SingleMuonRun2016C-ReReco-v1', '/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
- 						('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
-						('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
-				########  RUN G PROMPT		('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
- 						('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD'),
-# 						('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'), #change global tag: 199
-# 						('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD'),  ##change global tag: 199
-
+                           #                 ('SingleMuonRun2016F-ReReco-v1', '/SingleMuon/Run2016F-23Sep2016-v1/MINIAOD'),
+                           #                ('SingleMuonRun2016E-ReReco-v1', '/SingleMuon/Run2016E-23Sep2016-v1/MINIAOD'),
+                           #               ('SingleMuonRun2016D-ReReco-v1', '/SingleMuon/Run2016D-23Sep2016-v1/MINIAOD'),
+                           #              ('SingleMuonRun2016C-ReReco-v1','/SingleMuon/Run2016C-23Sep2016-v1/MINIAOD')
+                           #             ('SingleMuonRun2016B-ReReco-v3', '/SingleMuon/Run2016B-23Sep2016-v3/MINIAOD')
+                           #            ('SingleMuonRun2016G-PromptReco-v1',  '/SingleMuon/Run2016G-PromptReco-v1/MINIAOD')
+                           #              ('SingleMuonRun2016H-PromptReco-v3', '/SingleMuon/Run2016H-PromptReco-v3/MINIAOD'),
+#                            ('SingleMuonRun2016H-PromptReco-v2', '/SingleMuon/Run2016H-PromptReco-v2/MINIAOD') 
+                           #	    ('SingleMuonRun2016G-ReReco-v1', '/SingleMuon/Run2016G-23Sep2016-v1/MINIAOD')
             ]
 
-        lumi_lists = [
-			'Run2016MuonsOnly',
-		]
+#        for name, ana_dataset in dataset_details: # for pattuples
+        for name, dataset in dataset_details:
 
-        jobs = []
-        for lumi_name in lumi_lists:
-            ll = eval(lumi_name + '_ll') if lumi_name != 'NoLumiMask' else None
-            for dd in dataset_details:
-                jobs.append(dd + (lumi_name, ll))
-
-
-        for dataset_name, ana_dataset, lumi_name, lumi_list in jobs:
-            json_fn = 'tmp.json'
-            lumi_list.writeJSON(json_fn)
-            lumi_mask = json_fn
-
-            name = '%s_%s' % (lumi_name, dataset_name)
             print name
 
             new_py = open('nminus1effs.py').read()
-            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_Prompt_v14'\n"  #### RunH
+            new_py += "\nprocess.GlobalTag.globaltag = '80X_dataRun2_2016SeptRepro_v6'\n"
             open('nminus1effs_crab.py', 'wt').write(new_py)
 
             new_crab_cfg = crab_cfg % locals()
@@ -219,14 +217,13 @@ config.Data.splitting = 'LumiBased'
 config.Data.totalUnits = -1
 config.Data.unitsPerJob = 100
 #config.Data.lumiMask = 'tmp.json' #######
-# config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_MuonPhys.txt'
-config.Data.lumiMask = '%(lumi_mask)s' #######
+config.Data.lumiMask = 'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Cert_271036-282037_13TeV_PromptReco_Collisions16_JSON_NoL1T_MuonPhys.txt'
 '''
             new_crab_cfg = new_crab_cfg.replace('job_control', job_control)
             open('crabConfig.py', 'wt').write(new_crab_cfg)
 
             if not just_testing:
-                os.system('crab submit -c crabConfig.py') #--dryrun
+                os.system('crab submit -c crabConfig.py ') #--dryrun
 
         if not just_testing:
             os.system('rm crabConfig.py nminus1effs_crab.py nminus1effs_crab.pyc tmp.json')
@@ -240,21 +237,8 @@ config.Data.unitsPerJob  = 100000
 
         from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import *
         #samples =[DY120to200Powheg]
-        samples =[
- 				dy50to120, dy120to200, dy200to400, dy400to800, dy800to1400, 
- 				dy1400to2300, dy2300to3500, dy3500to4500, dy4500to6000,
- 				WZ, ZZ,
-				WZ_ext, ZZ_ext, 
- 				WW200to600, WW600to1200, WW1200to2500, WW2500,
- 				Wjets, Wantitop, tW,
- 				ttbar_lep_800to1200, ttbar_lep_1200to1800, ttbar_lep1800toInf, 
- 				qcd50to80, qcd80to120, qcd120to170, qcd170to300, qcd300to470, qcd470to600, 
- 				qcd600to800, qcd800to1000, qcd1000to1400, qcd1400to1800, qcd1800to2400, qcd2400to3200, qcd3200
-
-
-
-
-                  ]
+        samples =[ ttbar_lep50to500 ]
+        
         for sample in samples:
             #print sample.name
             open('crabConfig.py', 'wt').write(crab_cfg % sample)

--- a/test/NMinus1Effs/tasks.py
+++ b/test/NMinus1Effs/tasks.py
@@ -42,7 +42,7 @@ latest_dataset = '/SingleMuon/Run2015B-PromptReco-v1/AOD'
 #lumi_masks = ['Run2012PlusDCSOnlyMuonsOnly', 'Run2012MuonsOnly'] #, 'DCSOnly', 'Run2012']
 #lumi_masks = ['DCSOnly', 'Run2015', 'Run2015MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
 #lumi_masks = ['DCSOnly','Run2015', 'Run2015MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
-lumi_masks = ['Run2015MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
+lumi_masks = ['Run2016MuonsOnly'] #, 'Run2012PlusDCSOnlyMuonsOnly', 'DCSOnly']
 
 
 if cmd == 'setdirs':
@@ -57,7 +57,7 @@ elif cmd == 'maketagdirs':
     do('rm data mc plots')
     for which in ['data', 'mc', 'plots']:
         #d = '~/nobackup/zp2mu_ana_datamc_%s/%s' % (which,extra)
-        d = './zp2mu_ana_datamc_%s/%s' % (which,extra)
+        d = './zp2mu_ana_nminus1_%s/%s' % (which,extra)
         do('mkdir -p %s' % d)
         do('ln -s %s %s' % (d, which))
 
@@ -65,31 +65,49 @@ elif cmd == 'checkevents':
     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
     for sample in samples:
         print sample.name
-        do('grep TrigReport crab/crab_datamc_%s/res/*stdout | grep \' p$\' | sed -e "s/ +/ /g" | awk \'{ s += $4; t += $5; u += $6; } END { print "summary: total: ", s, "passed: ", t, "failed: ", u }\'' % sample.name)
+        do('grep TrigReport crab/crab_nminus1_%s/res/*stdout | grep \' p$\' | sed -e "s/ +/ /g" | awk \'{ s += $4; t += $5; u += $6; } END { print "summary: total: ", s, "passed: ", t, "failed: ", u }\'' % sample.name)
 
 elif cmd == 'checkstatus':
     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
     for sample in samples:
         print sample.name
-        do('crab status -d crab/crab_ana_datamc_%(name)s ' % sample)
+        do('crab status -d crab/crab_ana_nminus1_%(name)s ' % sample)
+        
+elif cmd == 'report':
+    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+    for sample in samples:
+        print sample.name
+        do('crab report -d crab/crab_ana_nminus1_%(name)s ' % sample)
+        
+elif cmd == 'resubmit':
+     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+     for sample in samples:
+         print sample.name
+         do('crab resubmit -d crab/crab_ana_nminus1_%(name)s ' % sample)
+
+elif cmd == 'kill':
+     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
+     for sample in samples:
+         print sample.name
+         do('crab kill -d crab/crab_ana_nminus1_%(name)s ' % sample)
 
 elif cmd == 'getoutput':
     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
     for sample in samples:
         print sample.name
-        do('crab getoutput -d crab/crab_ana_datamc_%(name)s ' % sample)
+        do('crab getoutput -d crab/crab_ana_nminus1_%(name)s --checksum=no' % sample)
 
 #elif cmd == 'publishmc':
 #    from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
 #    for sample in samples:
-#        do('crab -c crab/crab_datamc_%(name)s -publish >& crab/publish_logs/publish.crab_datamc_%(name)s &' % sample)
+#        do('crab -c crab/crab_nminus1_%(name)s -publish >& crab/publish_logs/publish.crab_nminus1_%(name)s &' % sample)
 
 elif cmd == 'anadatasets':
     print 'paste this into python/MCSamples.py:\n'
     from SUSYBSMAnalysis.Zprime2muAnalysis.MCSamples import samples
     for sample in samples:
         ana_dataset = None
-        fn = 'crab/publish_logs/publish.crab_datamc_%s' % sample.name
+        fn = 'crab/publish_logs/publish.crab_nminus1_%s' % sample.name
         # yay fragile parsing
         for line in open(fn):
             if line.startswith(' total events'):
@@ -111,7 +129,7 @@ elif cmd == 'gathermc':
             big_warn('no files matching %s' % pattern)
         else:
             files = glob.glob('crab/crab_ana%(extra)s_nminus1_%(name)s/results/zp2mu_histos*root' % locals())
-            hadd('nminus1_histos/ana_nminus1_%s.root' % name, files)
+            hadd('mc/ana_nminus1_%s.root' % name, files)
 
 elif cmd == 'gatherdata':
     extra = (extra[0] + '_') if extra else ''
@@ -119,20 +137,20 @@ elif cmd == 'gatherdata':
     for lumi_mask in lumi_masks:
         print lumi_mask
 #        dirs = glob.glob('crab/crab_ana_datamc_%s_ExpressPhysicsRun2015B*' % lumi_mask)
-        dirs = glob.glob('crab/crab_ana_nminus1_SingleMuonRun2015C*' )
+        dirs = glob.glob('crab/crab_ana_nminus1_SingleMuonRun2016*' )
 #        dirs = glob.glob('crab/crab_ana_datamc_%s_ExpressPhysicsRun2015B-Express_251161_251252' % lumi_mask)
         files = []
         for d in dirs:
             files += glob.glob(os.path.join(d, 'results/*.root'))
 
-        wdir = os.path.join('nminus1_histos', lumi_mask)
+        wdir = os.path.join('data', lumi_mask)
         os.mkdir(wdir)
         hadd(os.path.join(wdir, 'ana_nminus1_data.root'), files)
 
-        for dir in dirs:
-            do('crab status -d %(dir)s ; crab report -d %(dir)s ' % locals())
+#         for dir in dirs:
+#             do('crab status -d %(dir)s ; crab report -d %(dir)s ' % locals())
 
-        jsons = [os.path.join(dir, 'results/lumiSummary.json') for dir in dirs]
+        jsons = [os.path.join(dir, 'results/processedLumis.json') for dir in dirs]
         print jsons
         lls = [(j, LumiList(j)) for j in jsons]
         for (j1, ll1), (j2, ll2) in combinations(lls, 2):
@@ -142,13 +160,18 @@ elif cmd == 'gatherdata':
                 raise RuntimeError('\noverlap between %s and %s lumisections' % (j1,j2))
             else:
                 print cl
-                                        
-        reduce(lambda x,y: x|y, (LumiList(j) for j in jsons)).writeJSON('%(wdir)s/ana_datamc_data.forlumi.json' % locals())
-        #do('lumiCalc2.py -i %(wdir)s/ana_datamc_data.forlumi.json overview > %(wdir)s/ana_datamc_data.lumi' % locals())
-        #do('pixelLumiCalc.py -i %(wdir)s/ana_datamc_data.forlumi.json overview > %(wdir)s/ana_datamc_data.lumi' % locals())
-        do('brilcalc lumi -i %(wdir)s/ana_datamc_data.forlumi.json -n 0.962 > %(wdir)s/ana_datamc_data.lumi' % locals())
-        do('tail -5 %(wdir)s/ana_datamc_data.lumi' % locals())
+        
+        reduce(lambda x,y: x|y, (LumiList(j) for j in jsons)).writeJSON('%(wdir)s/ana_nminus1_data.forlumi.json' % locals())
+        do('brilcalc lumi --normtag /afs/cern.ch/user/l/lumipro/public/normtag_file/normtag_DATACERT.json -u /pb  -i %(wdir)s/ana_nminus1_data.forlumi.json  > %(wdir)s/ana_nminus1_data.lumi -b "STABLE BEAMS" ' % locals())
+        do('tail -5 %(wdir)s/ana_nminus1_data.lumi' % locals())
         print 'done with', lumi_mask, '\n'
+		#do('lumiCalc2.py -i %(wdir)s/ana_nminus1_data.forlumi.json overview > %(wdir)s/ana_nminus1_data.lumi' % locals())
+		#do('pixelLumiCalc.py -i %(wdir)s/ana_nminus1_data.forlumi.json overview > %(wdir)s/ana_nminus1_data.lumi' % locals())
+		#do('brilcalc lumi -i %(wdir)s/ana_nminus1_data.forlumi.json -n 0.962 > %(wdir)s/ana_nminus1_data.lumi' % locals())
+		
+
+		
+		   
 
 elif cmd == 'runrange':
     #cmd = 'dbs search --query="find min(run),max(run) where dataset=%s"' % latest_dataset
@@ -241,11 +264,11 @@ elif cmd == 'checkavail':
 elif cmd == 'drawall':
     extra = extra[0] if extra else ''
     for lumi_mask in lumi_masks:
-        r = do('python draw.py data/ana_datamc_%s %s > out.draw.%s' % (lumi_mask,extra,lumi_mask))
+        r = do('python draw.py data/ana_nminus1_%s %s > out.draw.%s' % (lumi_mask,extra,lumi_mask))
         if r != 0:
             sys.exit(r)
     do('mv out.draw.* plots/')
-    do('tlock ~/asdf/plots.tgz plots/datamc_* plots/out.draw.*')
+    do('tlock ~/asdf/plots.tgz plots/nminus1_* plots/out.draw.*')
 
 else:
     raise ValueError('command %s not recognized!' % cmd)


### PR DESCRIPTION
- plugins/HistosFromPAT.cc:
k factor calculation is now introduced;

- plugins/SimpleNtupler_miniAOD.cc:
in the tree, genInfo are taken BEFORE bremsstrahlung (I use NOIB info)

- plugins/Zprime2muLeptonProducer_miniAOD.cc:
pt bias correction is now introduced; CURRENTLY the bias is NOT applied; 

- python/OurSelection*:
cut on eta ( |eta| < 2.4) is now introduced

- src/GeneralizedEndpoint*:
code for pt bias correction

- test/DataMCSpectraComparison/histos.py:
set k factor boolean TRUE if you want to apply it  (currently is set on FALSE) 

- test/NMinus1Effs/nminus1effs*
to submit samples with their own filter  to compute N-1 efficiency (cut on opposite charge is now introduced)